### PR TITLE
Set the supported fraction digits to 19.

### DIFF
--- a/src/get-number/specs/get-number.de-at.spec.js
+++ b/src/get-number/specs/get-number.de-at.spec.js
@@ -1,5 +1,5 @@
 const getNumber = require('../get-number');
-const testCaseGenerator = require('./test-case-generator');
+const { testCaseGenerator, supportedNumberOfFractionDigits } = require('./test-case-generator');
 
 beforeEach(() => {
   // Making sure the `console.error` implementation is empty
@@ -10,47 +10,50 @@ beforeEach(() => {
 describe('Testing `getNumber` with `de-AT` locale on positive numbers', () => {
   test(`(Manually) It should return a positive decimal literal when given an 
   implicitly positive string representation`, () => {
-    expect(getNumber('0,0', 'de-AT')).toBeCloseTo(0.0, 20);
-    expect(getNumber('0,45', 'de-AT')).toBeCloseTo(0.45, 20);
-    expect(getNumber('0,3', 'de-AT')).toBeCloseTo(0.3, 20);
-    expect(getNumber('0,243225', 'de-AT')).toBeCloseTo(0.243225, 20);
-    expect(getNumber('200', 'de-AT')).toBeCloseTo(200, 20);
-    expect(getNumber('200,45', 'de-AT')).toBeCloseTo(200.45, 20);
-    expect(getNumber('873,00', 'de-AT')).toBeCloseTo(873.0, 20);
-    expect(getNumber('2 050', 'de-AT')).toBeCloseTo(2050, 20);
-    expect(getNumber('2 000,30', 'de-AT')).toBeCloseTo(2000.3, 20);
-    expect(getNumber('2 342,0', 'de-AT')).toBeCloseTo(2342.0, 20);
-    expect(getNumber('20 000', 'de-AT')).toBeCloseTo(20000, 20);
-    expect(getNumber('20 000,34', 'de-AT')).toBeCloseTo(20000.34, 20);
-    expect(getNumber('200 000', 'de-AT')).toBeCloseTo(200000, 20);
-    expect(getNumber('2 000 000', 'de-AT')).toBeCloseTo(2000000, 20);
-    expect(getNumber('12 054 100,55', 'de-AT')).toBeCloseTo(12054100.55, 20);
+    expect(getNumber('0,0', 'de-AT')).toBeCloseTo(0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('0,45', 'de-AT')).toBeCloseTo(0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('0,3', 'de-AT')).toBeCloseTo(0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('0,243225', 'de-AT')).toBeCloseTo(0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('200', 'de-AT')).toBeCloseTo(200, supportedNumberOfFractionDigits);
+    expect(getNumber('200,45', 'de-AT')).toBeCloseTo(200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('873,00', 'de-AT')).toBeCloseTo(873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('2 050', 'de-AT')).toBeCloseTo(2050, supportedNumberOfFractionDigits);
+    expect(getNumber('2 000,30', 'de-AT')).toBeCloseTo(2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('2 342,0', 'de-AT')).toBeCloseTo(2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('20 000', 'de-AT')).toBeCloseTo(20000, supportedNumberOfFractionDigits);
+    expect(getNumber('20 000,34', 'de-AT')).toBeCloseTo(20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('200 000', 'de-AT')).toBeCloseTo(200000, supportedNumberOfFractionDigits);
+    expect(getNumber('2 000 000', 'de-AT')).toBeCloseTo(2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('12 054 100,55', 'de-AT')).toBeCloseTo(12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Manually) It should return a positive decimal literal when given an 
   explicitly positive string representation`, () => {
-    expect(getNumber('+0,0', 'de-AT')).toBeCloseTo(0.0, 20);
-    expect(getNumber('+0,45', 'de-AT')).toBeCloseTo(0.45, 20);
-    expect(getNumber('+0,3', 'de-AT')).toBeCloseTo(0.3, 20);
-    expect(getNumber('+0,243225', 'de-AT')).toBeCloseTo(0.243225, 20);
-    expect(getNumber('+200', 'de-AT')).toBeCloseTo(200, 20);
-    expect(getNumber('+200,45', 'de-AT')).toBeCloseTo(200.45, 20);
-    expect(getNumber('+873,00', 'de-AT')).toBeCloseTo(873.0, 20);
-    expect(getNumber('+2 050', 'de-AT')).toBeCloseTo(2050, 20);
-    expect(getNumber('+2 000,30', 'de-AT')).toBeCloseTo(2000.3, 20);
-    expect(getNumber('+2 342,0', 'de-AT')).toBeCloseTo(2342.0, 20);
-    expect(getNumber('+20 000', 'de-AT')).toBeCloseTo(20000, 20);
-    expect(getNumber('+20 000,34', 'de-AT')).toBeCloseTo(20000.34, 20);
-    expect(getNumber('+200 000', 'de-AT')).toBeCloseTo(200000, 20);
-    expect(getNumber('+2 000 000', 'de-AT')).toBeCloseTo(2000000, 20);
-    expect(getNumber('+12 054 100,55', 'de-AT')).toBeCloseTo(12054100.55, 20);
+    expect(getNumber('+0,0', 'de-AT')).toBeCloseTo(0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+0,45', 'de-AT')).toBeCloseTo(0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('+0,3', 'de-AT')).toBeCloseTo(0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('+0,243225', 'de-AT')).toBeCloseTo(0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('+200', 'de-AT')).toBeCloseTo(200, supportedNumberOfFractionDigits);
+    expect(getNumber('+200,45', 'de-AT')).toBeCloseTo(200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('+873,00', 'de-AT')).toBeCloseTo(873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+2 050', 'de-AT')).toBeCloseTo(2050, supportedNumberOfFractionDigits);
+    expect(getNumber('+2 000,30', 'de-AT')).toBeCloseTo(2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('+2 342,0', 'de-AT')).toBeCloseTo(2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+20 000', 'de-AT')).toBeCloseTo(20000, supportedNumberOfFractionDigits);
+    expect(getNumber('+20 000,34', 'de-AT')).toBeCloseTo(20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('+200 000', 'de-AT')).toBeCloseTo(200000, supportedNumberOfFractionDigits);
+    expect(getNumber('+2 000 000', 'de-AT')).toBeCloseTo(2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('+12 054 100,55', 'de-AT')).toBeCloseTo(12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Automatically)(Range: [0, 1]) It should return a possible decimal literal when given an
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('de-AT', 0, 0, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-AT')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-AT')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -58,7 +61,10 @@ describe('Testing `getNumber` with `de-AT` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('de-AT', 1, 100, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-AT')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-AT')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -66,7 +72,10 @@ describe('Testing `getNumber` with `de-AT` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('de-AT', 100, 1000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-AT')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-AT')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -74,7 +83,10 @@ describe('Testing `getNumber` with `de-AT` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('de-AT', 1000, 10000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-AT')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-AT')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -82,7 +94,10 @@ describe('Testing `getNumber` with `de-AT` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('de-AT', 10000, 100000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-AT')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-AT')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -90,7 +105,10 @@ describe('Testing `getNumber` with `de-AT` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('de-AT', 100000, 1000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-AT')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-AT')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -98,7 +116,10 @@ describe('Testing `getNumber` with `de-AT` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('de-AT', 1000000, 10000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-AT')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-AT')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -106,7 +127,10 @@ describe('Testing `getNumber` with `de-AT` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('de-AT', 10000000, 100000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-AT')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-AT')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -114,7 +138,10 @@ describe('Testing `getNumber` with `de-AT` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('de-AT', 100000000, 1000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-AT')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-AT')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -122,7 +149,10 @@ describe('Testing `getNumber` with `de-AT` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('de-AT', 1000000000, 10000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-AT')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-AT')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -130,7 +160,10 @@ describe('Testing `getNumber` with `de-AT` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('de-AT', 10000000000, 100000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-AT')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-AT')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -138,7 +171,10 @@ describe('Testing `getNumber` with `de-AT` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('de-AT', 100000000000, 1000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-AT')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-AT')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -146,7 +182,10 @@ describe('Testing `getNumber` with `de-AT` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('de-AT', 1000000000000, 10000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-AT')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-AT')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -154,7 +193,10 @@ describe('Testing `getNumber` with `de-AT` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('de-AT', 10000000000000, 100000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-AT')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-AT')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 });
@@ -162,28 +204,31 @@ describe('Testing `getNumber` with `de-AT` locale on positive numbers', () => {
 describe('Testing `getNumber` with `de-AT` locale on negative numbers', () => {
   test(`(Manually) It should return a negative decimal literal when given a
   negative string representation`, () => {
-    expect(getNumber('-0,0', 'de-AT')).toBeCloseTo(-0.0, 20);
-    expect(getNumber('-0,45', 'de-AT')).toBeCloseTo(-0.45, 20);
-    expect(getNumber('-0,3', 'de-AT')).toBeCloseTo(-0.3, 20);
-    expect(getNumber('-0,243225', 'de-AT')).toBeCloseTo(-0.243225, 20);
-    expect(getNumber('-200', 'de-AT')).toBeCloseTo(-200, 20);
-    expect(getNumber('-200,45', 'de-AT')).toBeCloseTo(-200.45, 20);
-    expect(getNumber('-873,00', 'de-AT')).toBeCloseTo(-873.0, 20);
-    expect(getNumber('-2 050', 'de-AT')).toBeCloseTo(-2050, 20);
-    expect(getNumber('-2 000,30', 'de-AT')).toBeCloseTo(-2000.3, 20);
-    expect(getNumber('-2 342,0', 'de-AT')).toBeCloseTo(-2342.0, 20);
-    expect(getNumber('-20 000', 'de-AT')).toBeCloseTo(-20000, 20);
-    expect(getNumber('-20 000,34', 'de-AT')).toBeCloseTo(-20000.34, 20);
-    expect(getNumber('-200 000', 'de-AT')).toBeCloseTo(-200000, 20);
-    expect(getNumber('-2 000 000', 'de-AT')).toBeCloseTo(-2000000, 20);
-    expect(getNumber('-12 054 100,55', 'de-AT')).toBeCloseTo(-12054100.55, 20);
+    expect(getNumber('-0,0', 'de-AT')).toBeCloseTo(-0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-0,45', 'de-AT')).toBeCloseTo(-0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('-0,3', 'de-AT')).toBeCloseTo(-0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('-0,243225', 'de-AT')).toBeCloseTo(-0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('-200', 'de-AT')).toBeCloseTo(-200, supportedNumberOfFractionDigits);
+    expect(getNumber('-200,45', 'de-AT')).toBeCloseTo(-200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('-873,00', 'de-AT')).toBeCloseTo(-873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-2 050', 'de-AT')).toBeCloseTo(-2050, supportedNumberOfFractionDigits);
+    expect(getNumber('-2 000,30', 'de-AT')).toBeCloseTo(-2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('-2 342,0', 'de-AT')).toBeCloseTo(-2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-20 000', 'de-AT')).toBeCloseTo(-20000, supportedNumberOfFractionDigits);
+    expect(getNumber('-20 000,34', 'de-AT')).toBeCloseTo(-20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('-200 000', 'de-AT')).toBeCloseTo(-200000, supportedNumberOfFractionDigits);
+    expect(getNumber('-2 000 000', 'de-AT')).toBeCloseTo(-2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('-12 054 100,55', 'de-AT')).toBeCloseTo(-12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Automatically)(Range: [-1, 0]) It should return a possible decimal literal when given an
   negative string representation`, () => {
     const testCases = testCaseGenerator('de-AT', 0, -2, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-AT')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-AT')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -191,7 +236,10 @@ describe('Testing `getNumber` with `de-AT` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('de-AT', -100, -1, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-AT')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-AT')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -199,7 +247,10 @@ describe('Testing `getNumber` with `de-AT` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('de-AT', -1000, -100, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-AT')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-AT')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -207,7 +258,10 @@ describe('Testing `getNumber` with `de-AT` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('de-AT', -10000, -1000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-AT')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-AT')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -215,7 +269,10 @@ describe('Testing `getNumber` with `de-AT` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('de-AT', -100000, -10000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-AT')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-AT')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -223,7 +280,10 @@ describe('Testing `getNumber` with `de-AT` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('de-AT', -1000000, -100000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-AT')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-AT')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -231,7 +291,10 @@ describe('Testing `getNumber` with `de-AT` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('de-AT', -10000000, -1000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-AT')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-AT')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -239,7 +302,10 @@ describe('Testing `getNumber` with `de-AT` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('de-AT', -100000000, -10000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-AT')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-AT')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -247,7 +313,10 @@ describe('Testing `getNumber` with `de-AT` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('de-AT', -1000000000, -100000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-AT')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-AT')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -255,7 +324,10 @@ describe('Testing `getNumber` with `de-AT` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('de-AT', -10000000000, -1000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-AT')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-AT')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -263,7 +335,10 @@ describe('Testing `getNumber` with `de-AT` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('de-AT', -100000000000, -10000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-AT')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-AT')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -271,7 +346,10 @@ describe('Testing `getNumber` with `de-AT` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('de-AT', -1000000000000, -100000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-AT')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-AT')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -279,7 +357,10 @@ describe('Testing `getNumber` with `de-AT` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('de-AT', -10000000000000, -1000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-AT')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-AT')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 });

--- a/src/get-number/specs/get-number.de-ch.spec.js
+++ b/src/get-number/specs/get-number.de-ch.spec.js
@@ -1,5 +1,5 @@
 const getNumber = require('../get-number');
-const testCaseGenerator = require('./test-case-generator');
+const { testCaseGenerator, supportedNumberOfFractionDigits } = require('./test-case-generator');
 
 beforeEach(() => {
   // Making sure the `console.error` implementation is empty
@@ -10,47 +10,50 @@ beforeEach(() => {
 describe('Testing `getNumber` with `de-CH` locale on positive numbers', () => {
   test(`(Manually) It should return a positive decimal literal when given an 
   implicitly positive string representation`, () => {
-    expect(getNumber('0.0', 'de-CH')).toBeCloseTo(0.0, 20);
-    expect(getNumber('0.45', 'de-CH')).toBeCloseTo(0.45, 20);
-    expect(getNumber('0.3', 'de-CH')).toBeCloseTo(0.3, 20);
-    expect(getNumber('0.243225', 'de-CH')).toBeCloseTo(0.243225, 20);
-    expect(getNumber('200', 'de-CH')).toBeCloseTo(200, 20);
-    expect(getNumber('200.45', 'de-CH')).toBeCloseTo(200.45, 20);
-    expect(getNumber('873.00', 'de-CH')).toBeCloseTo(873.0, 20);
-    expect(getNumber('2\'050', 'de-CH')).toBeCloseTo(2050, 20);
-    expect(getNumber('2\'000.30', 'de-CH')).toBeCloseTo(2000.3, 20);
-    expect(getNumber('2\'342.0', 'de-CH')).toBeCloseTo(2342.0, 20);
-    expect(getNumber('20\'000', 'de-CH')).toBeCloseTo(20000, 20);
-    expect(getNumber('20\'000.34', 'de-CH')).toBeCloseTo(20000.34, 20);
-    expect(getNumber('200\'000', 'de-CH')).toBeCloseTo(200000, 20);
-    expect(getNumber('2\'000\'000', 'de-CH')).toBeCloseTo(2000000, 20);
-    expect(getNumber('12\'054\'100.55', 'de-CH')).toBeCloseTo(12054100.55, 20);
+    expect(getNumber('0.0', 'de-CH')).toBeCloseTo(0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('0.45', 'de-CH')).toBeCloseTo(0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('0.3', 'de-CH')).toBeCloseTo(0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('0.243225', 'de-CH')).toBeCloseTo(0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('200', 'de-CH')).toBeCloseTo(200, supportedNumberOfFractionDigits);
+    expect(getNumber('200.45', 'de-CH')).toBeCloseTo(200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('873.00', 'de-CH')).toBeCloseTo(873.0, supportedNumberOfFractionDigits);
+    expect(getNumber("2'050", 'de-CH')).toBeCloseTo(2050, supportedNumberOfFractionDigits);
+    expect(getNumber("2'000.30", 'de-CH')).toBeCloseTo(2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber("2'342.0", 'de-CH')).toBeCloseTo(2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber("20'000", 'de-CH')).toBeCloseTo(20000, supportedNumberOfFractionDigits);
+    expect(getNumber("20'000.34", 'de-CH')).toBeCloseTo(20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber("200'000", 'de-CH')).toBeCloseTo(200000, supportedNumberOfFractionDigits);
+    expect(getNumber("2'000'000", 'de-CH')).toBeCloseTo(2000000, supportedNumberOfFractionDigits);
+    expect(getNumber("12'054'100.55", 'de-CH')).toBeCloseTo(12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Manually) It should return a positive decimal literal when given an 
   explicitly positive string representation`, () => {
-    expect(getNumber('+0.0', 'de-CH')).toBeCloseTo(0.0, 20);
-    expect(getNumber('+0.45', 'de-CH')).toBeCloseTo(0.45, 20);
-    expect(getNumber('+0.3', 'de-CH')).toBeCloseTo(0.3, 20);
-    expect(getNumber('+0.243225', 'de-CH')).toBeCloseTo(0.243225, 20);
-    expect(getNumber('+200', 'de-CH')).toBeCloseTo(200, 20);
-    expect(getNumber('+200.45', 'de-CH')).toBeCloseTo(200.45, 20);
-    expect(getNumber('+873.00', 'de-CH')).toBeCloseTo(873.0, 20);
-    expect(getNumber('+2\'050', 'de-CH')).toBeCloseTo(2050, 20);
-    expect(getNumber('+2\'000.30', 'de-CH')).toBeCloseTo(2000.3, 20);
-    expect(getNumber('+2\'342.0', 'de-CH')).toBeCloseTo(2342.0, 20);
-    expect(getNumber('+20\'000', 'de-CH')).toBeCloseTo(20000, 20);
-    expect(getNumber('+20\'000.34', 'de-CH')).toBeCloseTo(20000.34, 20);
-    expect(getNumber('+200\'000', 'de-CH')).toBeCloseTo(200000, 20);
-    expect(getNumber('+2\'000\'000', 'de-CH')).toBeCloseTo(2000000, 20);
-    expect(getNumber('+12\'054\'100.55', 'de-CH')).toBeCloseTo(12054100.55, 20);
+    expect(getNumber('+0.0', 'de-CH')).toBeCloseTo(0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+0.45', 'de-CH')).toBeCloseTo(0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('+0.3', 'de-CH')).toBeCloseTo(0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('+0.243225', 'de-CH')).toBeCloseTo(0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('+200', 'de-CH')).toBeCloseTo(200, supportedNumberOfFractionDigits);
+    expect(getNumber('+200.45', 'de-CH')).toBeCloseTo(200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('+873.00', 'de-CH')).toBeCloseTo(873.0, supportedNumberOfFractionDigits);
+    expect(getNumber("+2'050", 'de-CH')).toBeCloseTo(2050, supportedNumberOfFractionDigits);
+    expect(getNumber("+2'000.30", 'de-CH')).toBeCloseTo(2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber("+2'342.0", 'de-CH')).toBeCloseTo(2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber("+20'000", 'de-CH')).toBeCloseTo(20000, supportedNumberOfFractionDigits);
+    expect(getNumber("+20'000.34", 'de-CH')).toBeCloseTo(20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber("+200'000", 'de-CH')).toBeCloseTo(200000, supportedNumberOfFractionDigits);
+    expect(getNumber("+2'000'000", 'de-CH')).toBeCloseTo(2000000, supportedNumberOfFractionDigits);
+    expect(getNumber("+12'054'100.55", 'de-CH')).toBeCloseTo(12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Automatically)(Range: [0, 1]) It should return a possible decimal literal when given an
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('de-CH', 0, 0, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-CH')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-CH')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -58,7 +61,10 @@ describe('Testing `getNumber` with `de-CH` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('de-CH', 1, 100, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-CH')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-CH')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -66,7 +72,10 @@ describe('Testing `getNumber` with `de-CH` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('de-CH', 100, 1000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-CH')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-CH')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -74,7 +83,10 @@ describe('Testing `getNumber` with `de-CH` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('de-CH', 1000, 10000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-CH')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-CH')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -82,7 +94,10 @@ describe('Testing `getNumber` with `de-CH` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('de-CH', 10000, 100000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-CH')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-CH')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -90,7 +105,10 @@ describe('Testing `getNumber` with `de-CH` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('de-CH', 100000, 1000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-CH')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-CH')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -98,7 +116,10 @@ describe('Testing `getNumber` with `de-CH` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('de-CH', 1000000, 10000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-CH')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-CH')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -106,7 +127,10 @@ describe('Testing `getNumber` with `de-CH` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('de-CH', 10000000, 100000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-CH')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-CH')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -114,7 +138,10 @@ describe('Testing `getNumber` with `de-CH` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('de-CH', 100000000, 1000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-CH')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-CH')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -122,7 +149,10 @@ describe('Testing `getNumber` with `de-CH` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('de-CH', 1000000000, 10000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-CH')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-CH')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -130,7 +160,10 @@ describe('Testing `getNumber` with `de-CH` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('de-CH', 10000000000, 100000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-CH')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-CH')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -138,7 +171,10 @@ describe('Testing `getNumber` with `de-CH` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('de-CH', 100000000000, 1000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-CH')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-CH')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -146,7 +182,10 @@ describe('Testing `getNumber` with `de-CH` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('de-CH', 1000000000000, 10000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-CH')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-CH')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -154,7 +193,10 @@ describe('Testing `getNumber` with `de-CH` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('de-CH', 10000000000000, 100000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-CH')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-CH')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 });
@@ -162,28 +204,31 @@ describe('Testing `getNumber` with `de-CH` locale on positive numbers', () => {
 describe('Testing `getNumber` with `de-CH` locale on negative numbers', () => {
   test(`(Manually) It should return a negative decimal literal when given a
   negative string representation`, () => {
-    expect(getNumber('-0.0', 'de-CH')).toBeCloseTo(-0.0, 20);
-    expect(getNumber('-0.45', 'de-CH')).toBeCloseTo(-0.45, 20);
-    expect(getNumber('-0.3', 'de-CH')).toBeCloseTo(-0.3, 20);
-    expect(getNumber('-0.243225', 'de-CH')).toBeCloseTo(-0.243225, 20);
-    expect(getNumber('-200', 'de-CH')).toBeCloseTo(-200, 20);
-    expect(getNumber('-200.45', 'de-CH')).toBeCloseTo(-200.45, 20);
-    expect(getNumber('-873.00', 'de-CH')).toBeCloseTo(-873.0, 20);
-    expect(getNumber('-2\'050', 'de-CH')).toBeCloseTo(-2050, 20);
-    expect(getNumber('-2\'000.30', 'de-CH')).toBeCloseTo(-2000.3, 20);
-    expect(getNumber('-2\'342.0', 'de-CH')).toBeCloseTo(-2342.0, 20);
-    expect(getNumber('-20\'000', 'de-CH')).toBeCloseTo(-20000, 20);
-    expect(getNumber('-20\'000.34', 'de-CH')).toBeCloseTo(-20000.34, 20);
-    expect(getNumber('-200\'000', 'de-CH')).toBeCloseTo(-200000, 20);
-    expect(getNumber('-2\'000\'000', 'de-CH')).toBeCloseTo(-2000000, 20);
-    expect(getNumber('-12\'054\'100.55', 'de-CH')).toBeCloseTo(-12054100.55, 20);
+    expect(getNumber('-0.0', 'de-CH')).toBeCloseTo(-0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-0.45', 'de-CH')).toBeCloseTo(-0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('-0.3', 'de-CH')).toBeCloseTo(-0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('-0.243225', 'de-CH')).toBeCloseTo(-0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('-200', 'de-CH')).toBeCloseTo(-200, supportedNumberOfFractionDigits);
+    expect(getNumber('-200.45', 'de-CH')).toBeCloseTo(-200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('-873.00', 'de-CH')).toBeCloseTo(-873.0, supportedNumberOfFractionDigits);
+    expect(getNumber("-2'050", 'de-CH')).toBeCloseTo(-2050, supportedNumberOfFractionDigits);
+    expect(getNumber("-2'000.30", 'de-CH')).toBeCloseTo(-2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber("-2'342.0", 'de-CH')).toBeCloseTo(-2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber("-20'000", 'de-CH')).toBeCloseTo(-20000, supportedNumberOfFractionDigits);
+    expect(getNumber("-20'000.34", 'de-CH')).toBeCloseTo(-20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber("-200'000", 'de-CH')).toBeCloseTo(-200000, supportedNumberOfFractionDigits);
+    expect(getNumber("-2'000'000", 'de-CH')).toBeCloseTo(-2000000, supportedNumberOfFractionDigits);
+    expect(getNumber("-12'054'100.55", 'de-CH')).toBeCloseTo(-12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Automatically)(Range: [-1, 0]) It should return a possible decimal literal when given an
   negative string representation`, () => {
     const testCases = testCaseGenerator('de-CH', 0, -2, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-CH')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-CH')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -191,7 +236,10 @@ describe('Testing `getNumber` with `de-CH` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('de-CH', -100, -1, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-CH')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-CH')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -199,7 +247,10 @@ describe('Testing `getNumber` with `de-CH` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('de-CH', -1000, -100, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-CH')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-CH')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -207,7 +258,10 @@ describe('Testing `getNumber` with `de-CH` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('de-CH', -10000, -1000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-CH')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-CH')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -215,7 +269,10 @@ describe('Testing `getNumber` with `de-CH` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('de-CH', -100000, -10000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-CH')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-CH')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -223,7 +280,10 @@ describe('Testing `getNumber` with `de-CH` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('de-CH', -1000000, -100000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-CH')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-CH')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -231,7 +291,10 @@ describe('Testing `getNumber` with `de-CH` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('de-CH', -10000000, -1000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-CH')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-CH')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -239,7 +302,10 @@ describe('Testing `getNumber` with `de-CH` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('de-CH', -100000000, -10000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-CH')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-CH')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -247,7 +313,10 @@ describe('Testing `getNumber` with `de-CH` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('de-CH', -1000000000, -100000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-CH')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-CH')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -255,7 +324,10 @@ describe('Testing `getNumber` with `de-CH` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('de-CH', -10000000000, -1000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-CH')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-CH')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -263,7 +335,10 @@ describe('Testing `getNumber` with `de-CH` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('de-CH', -100000000000, -10000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-CH')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-CH')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -271,7 +346,10 @@ describe('Testing `getNumber` with `de-CH` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('de-CH', -1000000000000, -100000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-CH')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-CH')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -279,7 +357,10 @@ describe('Testing `getNumber` with `de-CH` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('de-CH', -10000000000000, -1000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-CH')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-CH')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 });

--- a/src/get-number/specs/get-number.de-de.spec.js
+++ b/src/get-number/specs/get-number.de-de.spec.js
@@ -1,5 +1,5 @@
 const getNumber = require('../get-number');
-const testCaseGenerator = require('./test-case-generator');
+const { testCaseGenerator, supportedNumberOfFractionDigits } = require('./test-case-generator');
 
 beforeEach(() => {
   // Making sure the `console.error` implementation is empty
@@ -10,47 +10,50 @@ beforeEach(() => {
 describe('Testing `getNumber` with `de-DE` locale on positive numbers', () => {
   test(`(Manually) It should return a positive decimal literal when given an 
   implicitly positive string representation`, () => {
-    expect(getNumber('0,0', 'de-DE')).toBeCloseTo(0.0, 20);
-    expect(getNumber('0,45', 'de-DE')).toBeCloseTo(0.45, 20);
-    expect(getNumber('0,3', 'de-DE')).toBeCloseTo(0.3, 20);
-    expect(getNumber('0,243225', 'de-DE')).toBeCloseTo(0.243225, 20);
-    expect(getNumber('200', 'de-DE')).toBeCloseTo(200, 20);
-    expect(getNumber('200,45', 'de-DE')).toBeCloseTo(200.45, 20);
-    expect(getNumber('873,00', 'de-DE')).toBeCloseTo(873.0, 20);
-    expect(getNumber('2.050', 'de-DE')).toBeCloseTo(2050, 20);
-    expect(getNumber('2.000,30', 'de-DE')).toBeCloseTo(2000.3, 20);
-    expect(getNumber('2.342,0', 'de-DE')).toBeCloseTo(2342.0, 20);
-    expect(getNumber('20.000', 'de-DE')).toBeCloseTo(20000, 20);
-    expect(getNumber('20.000,34', 'de-DE')).toBeCloseTo(20000.34, 20);
-    expect(getNumber('200.000', 'de-DE')).toBeCloseTo(200000, 20);
-    expect(getNumber('2.000.000', 'de-DE')).toBeCloseTo(2000000, 20);
-    expect(getNumber('12.054.100,55', 'de-DE')).toBeCloseTo(12054100.55, 20);
+    expect(getNumber('0,0', 'de-DE')).toBeCloseTo(0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('0,45', 'de-DE')).toBeCloseTo(0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('0,3', 'de-DE')).toBeCloseTo(0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('0,243225', 'de-DE')).toBeCloseTo(0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('200', 'de-DE')).toBeCloseTo(200, supportedNumberOfFractionDigits);
+    expect(getNumber('200,45', 'de-DE')).toBeCloseTo(200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('873,00', 'de-DE')).toBeCloseTo(873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('2.050', 'de-DE')).toBeCloseTo(2050, supportedNumberOfFractionDigits);
+    expect(getNumber('2.000,30', 'de-DE')).toBeCloseTo(2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('2.342,0', 'de-DE')).toBeCloseTo(2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('20.000', 'de-DE')).toBeCloseTo(20000, supportedNumberOfFractionDigits);
+    expect(getNumber('20.000,34', 'de-DE')).toBeCloseTo(20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('200.000', 'de-DE')).toBeCloseTo(200000, supportedNumberOfFractionDigits);
+    expect(getNumber('2.000.000', 'de-DE')).toBeCloseTo(2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('12.054.100,55', 'de-DE')).toBeCloseTo(12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Manually) It should return a positive decimal literal when given an 
   explicitly positive string representation`, () => {
-    expect(getNumber('+0,0', 'de-DE')).toBeCloseTo(0.0, 20);
-    expect(getNumber('+0,45', 'de-DE')).toBeCloseTo(0.45, 20);
-    expect(getNumber('+0,3', 'de-DE')).toBeCloseTo(0.3, 20);
-    expect(getNumber('+0,243225', 'de-DE')).toBeCloseTo(0.243225, 20);
-    expect(getNumber('+200', 'de-DE')).toBeCloseTo(200, 20);
-    expect(getNumber('+200,45', 'de-DE')).toBeCloseTo(200.45, 20);
-    expect(getNumber('+873,00', 'de-DE')).toBeCloseTo(873.0, 20);
-    expect(getNumber('+2.050', 'de-DE')).toBeCloseTo(2050, 20);
-    expect(getNumber('+2.000,30', 'de-DE')).toBeCloseTo(2000.3, 20);
-    expect(getNumber('+2.342,0', 'de-DE')).toBeCloseTo(2342.0, 20);
-    expect(getNumber('+20.000', 'de-DE')).toBeCloseTo(20000, 20);
-    expect(getNumber('+20.000,34', 'de-DE')).toBeCloseTo(20000.34, 20);
-    expect(getNumber('+200.000', 'de-DE')).toBeCloseTo(200000, 20);
-    expect(getNumber('+2.000.000', 'de-DE')).toBeCloseTo(2000000, 20);
-    expect(getNumber('+12.054.100,55', 'de-DE')).toBeCloseTo(12054100.55, 20);
+    expect(getNumber('+0,0', 'de-DE')).toBeCloseTo(0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+0,45', 'de-DE')).toBeCloseTo(0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('+0,3', 'de-DE')).toBeCloseTo(0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('+0,243225', 'de-DE')).toBeCloseTo(0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('+200', 'de-DE')).toBeCloseTo(200, supportedNumberOfFractionDigits);
+    expect(getNumber('+200,45', 'de-DE')).toBeCloseTo(200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('+873,00', 'de-DE')).toBeCloseTo(873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+2.050', 'de-DE')).toBeCloseTo(2050, supportedNumberOfFractionDigits);
+    expect(getNumber('+2.000,30', 'de-DE')).toBeCloseTo(2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('+2.342,0', 'de-DE')).toBeCloseTo(2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+20.000', 'de-DE')).toBeCloseTo(20000, supportedNumberOfFractionDigits);
+    expect(getNumber('+20.000,34', 'de-DE')).toBeCloseTo(20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('+200.000', 'de-DE')).toBeCloseTo(200000, supportedNumberOfFractionDigits);
+    expect(getNumber('+2.000.000', 'de-DE')).toBeCloseTo(2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('+12.054.100,55', 'de-DE')).toBeCloseTo(12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Automatically)(Range: [0, 1]) It should return a possible decimal literal when given an
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('de-DE', 0, 0, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-DE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-DE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -58,7 +61,10 @@ describe('Testing `getNumber` with `de-DE` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('de-DE', 1, 100, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-DE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-DE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -66,7 +72,10 @@ describe('Testing `getNumber` with `de-DE` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('de-DE', 100, 1000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-DE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-DE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -74,7 +83,10 @@ describe('Testing `getNumber` with `de-DE` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('de-DE', 1000, 10000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-DE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-DE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -82,7 +94,10 @@ describe('Testing `getNumber` with `de-DE` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('de-DE', 10000, 100000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-DE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-DE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -90,7 +105,10 @@ describe('Testing `getNumber` with `de-DE` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('de-DE', 100000, 1000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-DE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-DE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -98,7 +116,10 @@ describe('Testing `getNumber` with `de-DE` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('de-DE', 1000000, 10000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-DE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-DE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -106,7 +127,10 @@ describe('Testing `getNumber` with `de-DE` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('de-DE', 10000000, 100000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-DE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-DE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -114,7 +138,10 @@ describe('Testing `getNumber` with `de-DE` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('de-DE', 100000000, 1000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-DE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-DE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -122,7 +149,10 @@ describe('Testing `getNumber` with `de-DE` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('de-DE', 1000000000, 10000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-DE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-DE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -130,7 +160,10 @@ describe('Testing `getNumber` with `de-DE` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('de-DE', 10000000000, 100000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-DE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-DE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -138,7 +171,10 @@ describe('Testing `getNumber` with `de-DE` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('de-DE', 100000000000, 1000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-DE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-DE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -146,7 +182,10 @@ describe('Testing `getNumber` with `de-DE` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('de-DE', 1000000000000, 10000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-DE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-DE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -154,7 +193,10 @@ describe('Testing `getNumber` with `de-DE` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('de-DE', 10000000000000, 100000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-DE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-DE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 });
@@ -162,28 +204,31 @@ describe('Testing `getNumber` with `de-DE` locale on positive numbers', () => {
 describe('Testing `getNumber` with `de-DE` locale on negative numbers', () => {
   test(`(Manually) It should return a negative decimal literal when given a
   negative string representation`, () => {
-    expect(getNumber('-0,0', 'de-DE')).toBeCloseTo(-0.0, 20);
-    expect(getNumber('-0,45', 'de-DE')).toBeCloseTo(-0.45, 20);
-    expect(getNumber('-0,3', 'de-DE')).toBeCloseTo(-0.3, 20);
-    expect(getNumber('-0,243225', 'de-DE')).toBeCloseTo(-0.243225, 20);
-    expect(getNumber('-200', 'de-DE')).toBeCloseTo(-200, 20);
-    expect(getNumber('-200,45', 'de-DE')).toBeCloseTo(-200.45, 20);
-    expect(getNumber('-873,00', 'de-DE')).toBeCloseTo(-873.0, 20);
-    expect(getNumber('-2.050', 'de-DE')).toBeCloseTo(-2050, 20);
-    expect(getNumber('-2.000,30', 'de-DE')).toBeCloseTo(-2000.3, 20);
-    expect(getNumber('-2.342,0', 'de-DE')).toBeCloseTo(-2342.0, 20);
-    expect(getNumber('-20.000', 'de-DE')).toBeCloseTo(-20000, 20);
-    expect(getNumber('-20.000,34', 'de-DE')).toBeCloseTo(-20000.34, 20);
-    expect(getNumber('-200.000', 'de-DE')).toBeCloseTo(-200000, 20);
-    expect(getNumber('-2.000.000', 'de-DE')).toBeCloseTo(-2000000, 20);
-    expect(getNumber('-12.054.100,55', 'de-DE')).toBeCloseTo(-12054100.55, 20);
+    expect(getNumber('-0,0', 'de-DE')).toBeCloseTo(-0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-0,45', 'de-DE')).toBeCloseTo(-0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('-0,3', 'de-DE')).toBeCloseTo(-0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('-0,243225', 'de-DE')).toBeCloseTo(-0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('-200', 'de-DE')).toBeCloseTo(-200, supportedNumberOfFractionDigits);
+    expect(getNumber('-200,45', 'de-DE')).toBeCloseTo(-200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('-873,00', 'de-DE')).toBeCloseTo(-873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-2.050', 'de-DE')).toBeCloseTo(-2050, supportedNumberOfFractionDigits);
+    expect(getNumber('-2.000,30', 'de-DE')).toBeCloseTo(-2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('-2.342,0', 'de-DE')).toBeCloseTo(-2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-20.000', 'de-DE')).toBeCloseTo(-20000, supportedNumberOfFractionDigits);
+    expect(getNumber('-20.000,34', 'de-DE')).toBeCloseTo(-20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('-200.000', 'de-DE')).toBeCloseTo(-200000, supportedNumberOfFractionDigits);
+    expect(getNumber('-2.000.000', 'de-DE')).toBeCloseTo(-2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('-12.054.100,55', 'de-DE')).toBeCloseTo(-12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Automatically)(Range: [-1, 0]) It should return a possible decimal literal when given an
   negative string representation`, () => {
     const testCases = testCaseGenerator('de-DE', 0, -2, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-DE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-DE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -191,7 +236,10 @@ describe('Testing `getNumber` with `de-DE` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('de-DE', -100, -1, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-DE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-DE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -199,7 +247,10 @@ describe('Testing `getNumber` with `de-DE` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('de-DE', -1000, -100, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-DE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-DE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -207,7 +258,10 @@ describe('Testing `getNumber` with `de-DE` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('de-DE', -10000, -1000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-DE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-DE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -215,7 +269,10 @@ describe('Testing `getNumber` with `de-DE` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('de-DE', -100000, -10000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-DE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-DE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -223,7 +280,10 @@ describe('Testing `getNumber` with `de-DE` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('de-DE', -1000000, -100000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-DE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-DE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -231,7 +291,10 @@ describe('Testing `getNumber` with `de-DE` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('de-DE', -10000000, -1000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-DE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-DE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -239,7 +302,10 @@ describe('Testing `getNumber` with `de-DE` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('de-DE', -100000000, -10000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-DE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-DE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -247,7 +313,10 @@ describe('Testing `getNumber` with `de-DE` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('de-DE', -1000000000, -100000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-DE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-DE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -255,7 +324,10 @@ describe('Testing `getNumber` with `de-DE` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('de-DE', -10000000000, -1000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-DE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-DE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -263,7 +335,10 @@ describe('Testing `getNumber` with `de-DE` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('de-DE', -100000000000, -10000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-DE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-DE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -271,7 +346,10 @@ describe('Testing `getNumber` with `de-DE` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('de-DE', -1000000000000, -100000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-DE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-DE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -279,7 +357,10 @@ describe('Testing `getNumber` with `de-DE` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('de-DE', -10000000000000, -1000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de-DE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de-DE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 });

--- a/src/get-number/specs/get-number.de.spec.js
+++ b/src/get-number/specs/get-number.de.spec.js
@@ -1,5 +1,5 @@
 const getNumber = require('../get-number');
-const testCaseGenerator = require('./test-case-generator');
+const { testCaseGenerator, supportedNumberOfFractionDigits } = require('./test-case-generator');
 
 beforeEach(() => {
   // Making sure the `console.error` implementation is empty
@@ -10,47 +10,50 @@ beforeEach(() => {
 describe('Testing `getNumber` with `de` locale on positive numbers', () => {
   test(`(Manually) It should return a positive decimal literal when given an 
   implicitly positive string representation`, () => {
-    expect(getNumber('0,0', 'de')).toBeCloseTo(0.0, 20);
-    expect(getNumber('0,45', 'de')).toBeCloseTo(0.45, 20);
-    expect(getNumber('0,3', 'de')).toBeCloseTo(0.3, 20);
-    expect(getNumber('0,243225', 'de')).toBeCloseTo(0.243225, 20);
-    expect(getNumber('200', 'de')).toBeCloseTo(200, 20);
-    expect(getNumber('200,45', 'de')).toBeCloseTo(200.45, 20);
-    expect(getNumber('873,00', 'de')).toBeCloseTo(873.0, 20);
-    expect(getNumber('2.050', 'de')).toBeCloseTo(2050, 20);
-    expect(getNumber('2.000,30', 'de')).toBeCloseTo(2000.3, 20);
-    expect(getNumber('2.342,0', 'de')).toBeCloseTo(2342.0, 20);
-    expect(getNumber('20.000', 'de')).toBeCloseTo(20000, 20);
-    expect(getNumber('20.000,34', 'de')).toBeCloseTo(20000.34, 20);
-    expect(getNumber('200.000', 'de')).toBeCloseTo(200000, 20);
-    expect(getNumber('2.000.000', 'de')).toBeCloseTo(2000000, 20);
-    expect(getNumber('12.054.100,55', 'de')).toBeCloseTo(12054100.55, 20);
+    expect(getNumber('0,0', 'de')).toBeCloseTo(0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('0,45', 'de')).toBeCloseTo(0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('0,3', 'de')).toBeCloseTo(0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('0,243225', 'de')).toBeCloseTo(0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('200', 'de')).toBeCloseTo(200, supportedNumberOfFractionDigits);
+    expect(getNumber('200,45', 'de')).toBeCloseTo(200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('873,00', 'de')).toBeCloseTo(873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('2.050', 'de')).toBeCloseTo(2050, supportedNumberOfFractionDigits);
+    expect(getNumber('2.000,30', 'de')).toBeCloseTo(2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('2.342,0', 'de')).toBeCloseTo(2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('20.000', 'de')).toBeCloseTo(20000, supportedNumberOfFractionDigits);
+    expect(getNumber('20.000,34', 'de')).toBeCloseTo(20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('200.000', 'de')).toBeCloseTo(200000, supportedNumberOfFractionDigits);
+    expect(getNumber('2.000.000', 'de')).toBeCloseTo(2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('12.054.100,55', 'de')).toBeCloseTo(12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Manually) It should return a positive decimal literal when given an 
   explicitly positive string representation`, () => {
-    expect(getNumber('+0,0', 'de')).toBeCloseTo(0.0, 20);
-    expect(getNumber('+0,45', 'de')).toBeCloseTo(0.45, 20);
-    expect(getNumber('+0,3', 'de')).toBeCloseTo(0.3, 20);
-    expect(getNumber('+0,243225', 'de')).toBeCloseTo(0.243225, 20);
-    expect(getNumber('+200', 'de')).toBeCloseTo(200, 20);
-    expect(getNumber('+200,45', 'de')).toBeCloseTo(200.45, 20);
-    expect(getNumber('+873,00', 'de')).toBeCloseTo(873.0, 20);
-    expect(getNumber('+2.050', 'de')).toBeCloseTo(2050, 20);
-    expect(getNumber('+2.000,30', 'de')).toBeCloseTo(2000.3, 20);
-    expect(getNumber('+2.342,0', 'de')).toBeCloseTo(2342.0, 20);
-    expect(getNumber('+20.000', 'de')).toBeCloseTo(20000, 20);
-    expect(getNumber('+20.000,34', 'de')).toBeCloseTo(20000.34, 20);
-    expect(getNumber('+200.000', 'de')).toBeCloseTo(200000, 20);
-    expect(getNumber('+2.000.000', 'de')).toBeCloseTo(2000000, 20);
-    expect(getNumber('+12.054.100,55', 'de')).toBeCloseTo(12054100.55, 20);
+    expect(getNumber('+0,0', 'de')).toBeCloseTo(0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+0,45', 'de')).toBeCloseTo(0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('+0,3', 'de')).toBeCloseTo(0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('+0,243225', 'de')).toBeCloseTo(0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('+200', 'de')).toBeCloseTo(200, supportedNumberOfFractionDigits);
+    expect(getNumber('+200,45', 'de')).toBeCloseTo(200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('+873,00', 'de')).toBeCloseTo(873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+2.050', 'de')).toBeCloseTo(2050, supportedNumberOfFractionDigits);
+    expect(getNumber('+2.000,30', 'de')).toBeCloseTo(2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('+2.342,0', 'de')).toBeCloseTo(2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+20.000', 'de')).toBeCloseTo(20000, supportedNumberOfFractionDigits);
+    expect(getNumber('+20.000,34', 'de')).toBeCloseTo(20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('+200.000', 'de')).toBeCloseTo(200000, supportedNumberOfFractionDigits);
+    expect(getNumber('+2.000.000', 'de')).toBeCloseTo(2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('+12.054.100,55', 'de')).toBeCloseTo(12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Automatically)(Range: [0, 1]) It should return a possible decimal literal when given an
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('de', 0, 0, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -58,7 +61,10 @@ describe('Testing `getNumber` with `de` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('de', 1, 100, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -66,7 +72,10 @@ describe('Testing `getNumber` with `de` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('de', 100, 1000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -74,7 +83,10 @@ describe('Testing `getNumber` with `de` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('de', 1000, 10000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -82,7 +94,10 @@ describe('Testing `getNumber` with `de` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('de', 10000, 100000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -90,7 +105,10 @@ describe('Testing `getNumber` with `de` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('de', 100000, 1000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -98,7 +116,10 @@ describe('Testing `getNumber` with `de` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('de', 1000000, 10000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -106,7 +127,10 @@ describe('Testing `getNumber` with `de` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('de', 10000000, 100000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -114,7 +138,10 @@ describe('Testing `getNumber` with `de` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('de', 100000000, 1000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -122,7 +149,10 @@ describe('Testing `getNumber` with `de` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('de', 1000000000, 10000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -130,7 +160,10 @@ describe('Testing `getNumber` with `de` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('de', 10000000000, 100000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -138,7 +171,10 @@ describe('Testing `getNumber` with `de` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('de', 100000000000, 1000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -146,7 +182,10 @@ describe('Testing `getNumber` with `de` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('de', 1000000000000, 10000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -154,7 +193,10 @@ describe('Testing `getNumber` with `de` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('de', 10000000000000, 100000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 });
@@ -162,28 +204,31 @@ describe('Testing `getNumber` with `de` locale on positive numbers', () => {
 describe('Testing `getNumber` with `de` locale on negative numbers', () => {
   test(`(Manually) It should return a negative decimal literal when given a
   negative string representation`, () => {
-    expect(getNumber('-0,0', 'de')).toBeCloseTo(-0.0, 20);
-    expect(getNumber('-0,45', 'de')).toBeCloseTo(-0.45, 20);
-    expect(getNumber('-0,3', 'de')).toBeCloseTo(-0.3, 20);
-    expect(getNumber('-0,243225', 'de')).toBeCloseTo(-0.243225, 20);
-    expect(getNumber('-200', 'de')).toBeCloseTo(-200, 20);
-    expect(getNumber('-200,45', 'de')).toBeCloseTo(-200.45, 20);
-    expect(getNumber('-873,00', 'de')).toBeCloseTo(-873.0, 20);
-    expect(getNumber('-2.050', 'de')).toBeCloseTo(-2050, 20);
-    expect(getNumber('-2.000,30', 'de')).toBeCloseTo(-2000.3, 20);
-    expect(getNumber('-2.342,0', 'de')).toBeCloseTo(-2342.0, 20);
-    expect(getNumber('-20.000', 'de')).toBeCloseTo(-20000, 20);
-    expect(getNumber('-20.000,34', 'de')).toBeCloseTo(-20000.34, 20);
-    expect(getNumber('-200.000', 'de')).toBeCloseTo(-200000, 20);
-    expect(getNumber('-2.000.000', 'de')).toBeCloseTo(-2000000, 20);
-    expect(getNumber('-12.054.100,55', 'de')).toBeCloseTo(-12054100.55, 20);
+    expect(getNumber('-0,0', 'de')).toBeCloseTo(-0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-0,45', 'de')).toBeCloseTo(-0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('-0,3', 'de')).toBeCloseTo(-0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('-0,243225', 'de')).toBeCloseTo(-0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('-200', 'de')).toBeCloseTo(-200, supportedNumberOfFractionDigits);
+    expect(getNumber('-200,45', 'de')).toBeCloseTo(-200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('-873,00', 'de')).toBeCloseTo(-873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-2.050', 'de')).toBeCloseTo(-2050, supportedNumberOfFractionDigits);
+    expect(getNumber('-2.000,30', 'de')).toBeCloseTo(-2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('-2.342,0', 'de')).toBeCloseTo(-2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-20.000', 'de')).toBeCloseTo(-20000, supportedNumberOfFractionDigits);
+    expect(getNumber('-20.000,34', 'de')).toBeCloseTo(-20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('-200.000', 'de')).toBeCloseTo(-200000, supportedNumberOfFractionDigits);
+    expect(getNumber('-2.000.000', 'de')).toBeCloseTo(-2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('-12.054.100,55', 'de')).toBeCloseTo(-12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Automatically)(Range: [-1, 0]) It should return a possible decimal literal when given an
   negative string representation`, () => {
     const testCases = testCaseGenerator('de', 0, -2, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -191,7 +236,10 @@ describe('Testing `getNumber` with `de` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('de', -100, -1, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -199,7 +247,10 @@ describe('Testing `getNumber` with `de` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('de', -1000, -100, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -207,7 +258,10 @@ describe('Testing `getNumber` with `de` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('de', -10000, -1000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -215,7 +269,10 @@ describe('Testing `getNumber` with `de` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('de', -100000, -10000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -223,7 +280,10 @@ describe('Testing `getNumber` with `de` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('de', -1000000, -100000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -231,7 +291,10 @@ describe('Testing `getNumber` with `de` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('de', -10000000, -1000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -239,7 +302,10 @@ describe('Testing `getNumber` with `de` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('de', -100000000, -10000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -247,7 +313,10 @@ describe('Testing `getNumber` with `de` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('de', -1000000000, -100000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -255,7 +324,10 @@ describe('Testing `getNumber` with `de` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('de', -10000000000, -1000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -263,7 +335,10 @@ describe('Testing `getNumber` with `de` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('de', -100000000000, -10000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -271,7 +346,10 @@ describe('Testing `getNumber` with `de` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('de', -1000000000000, -100000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -279,7 +357,10 @@ describe('Testing `getNumber` with `de` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('de', -10000000000000, -1000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'de')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'de')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 });

--- a/src/get-number/specs/get-number.en-au.spec.js
+++ b/src/get-number/specs/get-number.en-au.spec.js
@@ -1,5 +1,5 @@
 const getNumber = require('../get-number');
-const testCaseGenerator = require('./test-case-generator');
+const { testCaseGenerator, supportedNumberOfFractionDigits } = require('./test-case-generator');
 
 beforeEach(() => {
   // Making sure the `console.error` implementation is empty
@@ -10,47 +10,50 @@ beforeEach(() => {
 describe('Testing `getNumber` with `en-au` locale on positive numbers', () => {
   test(`(Manually) It should return a positive decimal literal when given an 
   implicitly positive string representation`, () => {
-    expect(getNumber('0.0', 'en-au')).toBeCloseTo(0.0, 20);
-    expect(getNumber('0.45', 'en-au')).toBeCloseTo(0.45, 20);
-    expect(getNumber('0.3', 'en-au')).toBeCloseTo(0.3, 20);
-    expect(getNumber('0.243225', 'en-au')).toBeCloseTo(0.243225, 20);
-    expect(getNumber('200', 'en-au')).toBeCloseTo(200, 20);
-    expect(getNumber('200.45', 'en-au')).toBeCloseTo(200.45, 20);
-    expect(getNumber('873.00', 'en-au')).toBeCloseTo(873.0, 20);
-    expect(getNumber('2,050', 'en-au')).toBeCloseTo(2050, 20);
-    expect(getNumber('2,000.30', 'en-au')).toBeCloseTo(2000.3, 20);
-    expect(getNumber('2,342.0', 'en-au')).toBeCloseTo(2342.0, 20);
-    expect(getNumber('20,000', 'en-au')).toBeCloseTo(20000, 20);
-    expect(getNumber('20,000.34', 'en-au')).toBeCloseTo(20000.34, 20);
-    expect(getNumber('200,000', 'en-au')).toBeCloseTo(200000, 20);
-    expect(getNumber('2,000,000', 'en-au')).toBeCloseTo(2000000, 20);
-    expect(getNumber('12,054,100.55', 'en-au')).toBeCloseTo(12054100.55, 20);
+    expect(getNumber('0.0', 'en-au')).toBeCloseTo(0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('0.45', 'en-au')).toBeCloseTo(0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('0.3', 'en-au')).toBeCloseTo(0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('0.243225', 'en-au')).toBeCloseTo(0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('200', 'en-au')).toBeCloseTo(200, supportedNumberOfFractionDigits);
+    expect(getNumber('200.45', 'en-au')).toBeCloseTo(200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('873.00', 'en-au')).toBeCloseTo(873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('2,050', 'en-au')).toBeCloseTo(2050, supportedNumberOfFractionDigits);
+    expect(getNumber('2,000.30', 'en-au')).toBeCloseTo(2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('2,342.0', 'en-au')).toBeCloseTo(2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('20,000', 'en-au')).toBeCloseTo(20000, supportedNumberOfFractionDigits);
+    expect(getNumber('20,000.34', 'en-au')).toBeCloseTo(20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('200,000', 'en-au')).toBeCloseTo(200000, supportedNumberOfFractionDigits);
+    expect(getNumber('2,000,000', 'en-au')).toBeCloseTo(2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('12,054,100.55', 'en-au')).toBeCloseTo(12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Manually) It should return a positive decimal literal when given an 
   explicitly positive string representation`, () => {
-    expect(getNumber('+0.0', 'en-au')).toBeCloseTo(0.0, 20);
-    expect(getNumber('+0.45', 'en-au')).toBeCloseTo(0.45, 20);
-    expect(getNumber('+0.3', 'en-au')).toBeCloseTo(0.3, 20);
-    expect(getNumber('+0.243225', 'en-au')).toBeCloseTo(0.243225, 20);
-    expect(getNumber('+200', 'en-au')).toBeCloseTo(200, 20);
-    expect(getNumber('+200.45', 'en-au')).toBeCloseTo(200.45, 20);
-    expect(getNumber('+873.00', 'en-au')).toBeCloseTo(873.0, 20);
-    expect(getNumber('+2,050', 'en-au')).toBeCloseTo(2050, 20);
-    expect(getNumber('+2,000.30', 'en-au')).toBeCloseTo(2000.3, 20);
-    expect(getNumber('+2,342.0', 'en-au')).toBeCloseTo(2342.0, 20);
-    expect(getNumber('+20,000', 'en-au')).toBeCloseTo(20000, 20);
-    expect(getNumber('+20,000.34', 'en-au')).toBeCloseTo(20000.34, 20);
-    expect(getNumber('+200,000', 'en-au')).toBeCloseTo(200000, 20);
-    expect(getNumber('+2,000,000', 'en-au')).toBeCloseTo(2000000, 20);
-    expect(getNumber('+12,054,100.55', 'en-au')).toBeCloseTo(12054100.55, 20);
+    expect(getNumber('+0.0', 'en-au')).toBeCloseTo(0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+0.45', 'en-au')).toBeCloseTo(0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('+0.3', 'en-au')).toBeCloseTo(0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('+0.243225', 'en-au')).toBeCloseTo(0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('+200', 'en-au')).toBeCloseTo(200, supportedNumberOfFractionDigits);
+    expect(getNumber('+200.45', 'en-au')).toBeCloseTo(200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('+873.00', 'en-au')).toBeCloseTo(873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+2,050', 'en-au')).toBeCloseTo(2050, supportedNumberOfFractionDigits);
+    expect(getNumber('+2,000.30', 'en-au')).toBeCloseTo(2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('+2,342.0', 'en-au')).toBeCloseTo(2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+20,000', 'en-au')).toBeCloseTo(20000, supportedNumberOfFractionDigits);
+    expect(getNumber('+20,000.34', 'en-au')).toBeCloseTo(20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('+200,000', 'en-au')).toBeCloseTo(200000, supportedNumberOfFractionDigits);
+    expect(getNumber('+2,000,000', 'en-au')).toBeCloseTo(2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('+12,054,100.55', 'en-au')).toBeCloseTo(12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Automatically)(Range: [0, 1]) It should return a possible decimal literal when given an
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-au', 0, 0, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-au')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-au')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -58,7 +61,10 @@ describe('Testing `getNumber` with `en-au` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-au', 1, 100, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-au')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-au')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -66,7 +72,10 @@ describe('Testing `getNumber` with `en-au` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-au', 100, 1000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-au')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-au')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -74,7 +83,10 @@ describe('Testing `getNumber` with `en-au` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-au', 1000, 10000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-au')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-au')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -82,7 +94,10 @@ describe('Testing `getNumber` with `en-au` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-au', 10000, 100000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-au')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-au')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -90,7 +105,10 @@ describe('Testing `getNumber` with `en-au` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-au', 100000, 1000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-au')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-au')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -98,7 +116,10 @@ describe('Testing `getNumber` with `en-au` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-au', 1000000, 10000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-au')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-au')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -106,7 +127,10 @@ describe('Testing `getNumber` with `en-au` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-au', 10000000, 100000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-au')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-au')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -114,7 +138,10 @@ describe('Testing `getNumber` with `en-au` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-au', 100000000, 1000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-au')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-au')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -122,7 +149,10 @@ describe('Testing `getNumber` with `en-au` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-au', 1000000000, 10000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-au')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-au')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -130,7 +160,10 @@ describe('Testing `getNumber` with `en-au` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-au', 10000000000, 100000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-au')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-au')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -138,7 +171,10 @@ describe('Testing `getNumber` with `en-au` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-au', 100000000000, 1000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-au')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-au')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -146,7 +182,10 @@ describe('Testing `getNumber` with `en-au` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-au', 1000000000000, 10000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-au')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-au')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -154,7 +193,10 @@ describe('Testing `getNumber` with `en-au` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-au', 10000000000000, 100000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-au')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-au')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 });
@@ -162,28 +204,31 @@ describe('Testing `getNumber` with `en-au` locale on positive numbers', () => {
 describe('Testing `getNumber` with `en-au` locale on negative numbers', () => {
   test(`(Manually) It should return a negative decimal literal when given a
   negative string representation`, () => {
-    expect(getNumber('-0.0', 'en-au')).toBeCloseTo(-0.0, 20);
-    expect(getNumber('-0.45', 'en-au')).toBeCloseTo(-0.45, 20);
-    expect(getNumber('-0.3', 'en-au')).toBeCloseTo(-0.3, 20);
-    expect(getNumber('-0.243225', 'en-au')).toBeCloseTo(-0.243225, 20);
-    expect(getNumber('-200', 'en-au')).toBeCloseTo(-200, 20);
-    expect(getNumber('-200.45', 'en-au')).toBeCloseTo(-200.45, 20);
-    expect(getNumber('-873.00', 'en-au')).toBeCloseTo(-873.0, 20);
-    expect(getNumber('-2,050', 'en-au')).toBeCloseTo(-2050, 20);
-    expect(getNumber('-2,000.30', 'en-au')).toBeCloseTo(-2000.3, 20);
-    expect(getNumber('-2,342.0', 'en-au')).toBeCloseTo(-2342.0, 20);
-    expect(getNumber('-20,000', 'en-au')).toBeCloseTo(-20000, 20);
-    expect(getNumber('-20,000.34', 'en-au')).toBeCloseTo(-20000.34, 20);
-    expect(getNumber('-200,000', 'en-au')).toBeCloseTo(-200000, 20);
-    expect(getNumber('-2,000,000', 'en-au')).toBeCloseTo(-2000000, 20);
-    expect(getNumber('-12,054,100.55', 'en-au')).toBeCloseTo(-12054100.55, 20);
+    expect(getNumber('-0.0', 'en-au')).toBeCloseTo(-0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-0.45', 'en-au')).toBeCloseTo(-0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('-0.3', 'en-au')).toBeCloseTo(-0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('-0.243225', 'en-au')).toBeCloseTo(-0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('-200', 'en-au')).toBeCloseTo(-200, supportedNumberOfFractionDigits);
+    expect(getNumber('-200.45', 'en-au')).toBeCloseTo(-200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('-873.00', 'en-au')).toBeCloseTo(-873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-2,050', 'en-au')).toBeCloseTo(-2050, supportedNumberOfFractionDigits);
+    expect(getNumber('-2,000.30', 'en-au')).toBeCloseTo(-2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('-2,342.0', 'en-au')).toBeCloseTo(-2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-20,000', 'en-au')).toBeCloseTo(-20000, supportedNumberOfFractionDigits);
+    expect(getNumber('-20,000.34', 'en-au')).toBeCloseTo(-20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('-200,000', 'en-au')).toBeCloseTo(-200000, supportedNumberOfFractionDigits);
+    expect(getNumber('-2,000,000', 'en-au')).toBeCloseTo(-2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('-12,054,100.55', 'en-au')).toBeCloseTo(-12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Automatically)(Range: [-1, 0]) It should return a possible decimal literal when given an
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-au', 0, -2, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-au')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-au')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -191,7 +236,10 @@ describe('Testing `getNumber` with `en-au` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-au', -100, -1, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-au')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-au')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -199,7 +247,10 @@ describe('Testing `getNumber` with `en-au` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-au', -1000, -100, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-au')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-au')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -207,7 +258,10 @@ describe('Testing `getNumber` with `en-au` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-au', -10000, -1000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-au')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-au')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -215,7 +269,10 @@ describe('Testing `getNumber` with `en-au` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-au', -100000, -10000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-au')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-au')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -223,7 +280,10 @@ describe('Testing `getNumber` with `en-au` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-au', -1000000, -100000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-au')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-au')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -231,7 +291,10 @@ describe('Testing `getNumber` with `en-au` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-au', -10000000, -1000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-au')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-au')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -239,7 +302,10 @@ describe('Testing `getNumber` with `en-au` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-au', -100000000, -10000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-au')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-au')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -247,7 +313,10 @@ describe('Testing `getNumber` with `en-au` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-au', -1000000000, -100000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-au')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-au')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -255,7 +324,10 @@ describe('Testing `getNumber` with `en-au` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-au', -10000000000, -1000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-au')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-au')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -263,7 +335,10 @@ describe('Testing `getNumber` with `en-au` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-au', -100000000000, -10000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-au')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-au')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -271,7 +346,10 @@ describe('Testing `getNumber` with `en-au` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-au', -1000000000000, -100000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-au')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-au')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -279,7 +357,10 @@ describe('Testing `getNumber` with `en-au` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-au', -10000000000000, -1000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-au')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-au')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 });

--- a/src/get-number/specs/get-number.en-ca.spec.js
+++ b/src/get-number/specs/get-number.en-ca.spec.js
@@ -1,5 +1,5 @@
 const getNumber = require('../get-number');
-const testCaseGenerator = require('./test-case-generator');
+const { testCaseGenerator, supportedNumberOfFractionDigits } = require('./test-case-generator');
 
 beforeEach(() => {
   // Making sure the `console.error` implementation is empty
@@ -10,47 +10,50 @@ beforeEach(() => {
 describe('Testing `getNumber` with `en-CA` locale on positive numbers', () => {
   test(`(Manually) It should return a positive decimal literal when given an 
   implicitly positive string representation`, () => {
-    expect(getNumber('0.0', 'en-CA')).toBeCloseTo(0.0, 20);
-    expect(getNumber('0.45', 'en-CA')).toBeCloseTo(0.45, 20);
-    expect(getNumber('0.3', 'en-CA')).toBeCloseTo(0.3, 20);
-    expect(getNumber('0.243225', 'en-CA')).toBeCloseTo(0.243225, 20);
-    expect(getNumber('200', 'en-CA')).toBeCloseTo(200, 20);
-    expect(getNumber('200.45', 'en-CA')).toBeCloseTo(200.45, 20);
-    expect(getNumber('873.00', 'en-CA')).toBeCloseTo(873.0, 20);
-    expect(getNumber('2,050', 'en-CA')).toBeCloseTo(2050, 20);
-    expect(getNumber('2,000.30', 'en-CA')).toBeCloseTo(2000.3, 20);
-    expect(getNumber('2,342.0', 'en-CA')).toBeCloseTo(2342.0, 20);
-    expect(getNumber('20,000', 'en-CA')).toBeCloseTo(20000, 20);
-    expect(getNumber('20,000.34', 'en-CA')).toBeCloseTo(20000.34, 20);
-    expect(getNumber('200,000', 'en-CA')).toBeCloseTo(200000, 20);
-    expect(getNumber('2,000,000', 'en-CA')).toBeCloseTo(2000000, 20);
-    expect(getNumber('12,054,100.55', 'en-CA')).toBeCloseTo(12054100.55, 20);
+    expect(getNumber('0.0', 'en-CA')).toBeCloseTo(0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('0.45', 'en-CA')).toBeCloseTo(0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('0.3', 'en-CA')).toBeCloseTo(0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('0.243225', 'en-CA')).toBeCloseTo(0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('200', 'en-CA')).toBeCloseTo(200, supportedNumberOfFractionDigits);
+    expect(getNumber('200.45', 'en-CA')).toBeCloseTo(200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('873.00', 'en-CA')).toBeCloseTo(873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('2,050', 'en-CA')).toBeCloseTo(2050, supportedNumberOfFractionDigits);
+    expect(getNumber('2,000.30', 'en-CA')).toBeCloseTo(2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('2,342.0', 'en-CA')).toBeCloseTo(2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('20,000', 'en-CA')).toBeCloseTo(20000, supportedNumberOfFractionDigits);
+    expect(getNumber('20,000.34', 'en-CA')).toBeCloseTo(20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('200,000', 'en-CA')).toBeCloseTo(200000, supportedNumberOfFractionDigits);
+    expect(getNumber('2,000,000', 'en-CA')).toBeCloseTo(2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('12,054,100.55', 'en-CA')).toBeCloseTo(12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Manually) It should return a positive decimal literal when given an 
   explicitly positive string representation`, () => {
-    expect(getNumber('+0.0', 'en-CA')).toBeCloseTo(0.0, 20);
-    expect(getNumber('+0.45', 'en-CA')).toBeCloseTo(0.45, 20);
-    expect(getNumber('+0.3', 'en-CA')).toBeCloseTo(0.3, 20);
-    expect(getNumber('+0.243225', 'en-CA')).toBeCloseTo(0.243225, 20);
-    expect(getNumber('+200', 'en-CA')).toBeCloseTo(200, 20);
-    expect(getNumber('+200.45', 'en-CA')).toBeCloseTo(200.45, 20);
-    expect(getNumber('+873.00', 'en-CA')).toBeCloseTo(873.0, 20);
-    expect(getNumber('+2,050', 'en-CA')).toBeCloseTo(2050, 20);
-    expect(getNumber('+2,000.30', 'en-CA')).toBeCloseTo(2000.3, 20);
-    expect(getNumber('+2,342.0', 'en-CA')).toBeCloseTo(2342.0, 20);
-    expect(getNumber('+20,000', 'en-CA')).toBeCloseTo(20000, 20);
-    expect(getNumber('+20,000.34', 'en-CA')).toBeCloseTo(20000.34, 20);
-    expect(getNumber('+200,000', 'en-CA')).toBeCloseTo(200000, 20);
-    expect(getNumber('+2,000,000', 'en-CA')).toBeCloseTo(2000000, 20);
-    expect(getNumber('+12,054,100.55', 'en-CA')).toBeCloseTo(12054100.55, 20);
+    expect(getNumber('+0.0', 'en-CA')).toBeCloseTo(0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+0.45', 'en-CA')).toBeCloseTo(0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('+0.3', 'en-CA')).toBeCloseTo(0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('+0.243225', 'en-CA')).toBeCloseTo(0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('+200', 'en-CA')).toBeCloseTo(200, supportedNumberOfFractionDigits);
+    expect(getNumber('+200.45', 'en-CA')).toBeCloseTo(200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('+873.00', 'en-CA')).toBeCloseTo(873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+2,050', 'en-CA')).toBeCloseTo(2050, supportedNumberOfFractionDigits);
+    expect(getNumber('+2,000.30', 'en-CA')).toBeCloseTo(2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('+2,342.0', 'en-CA')).toBeCloseTo(2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+20,000', 'en-CA')).toBeCloseTo(20000, supportedNumberOfFractionDigits);
+    expect(getNumber('+20,000.34', 'en-CA')).toBeCloseTo(20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('+200,000', 'en-CA')).toBeCloseTo(200000, supportedNumberOfFractionDigits);
+    expect(getNumber('+2,000,000', 'en-CA')).toBeCloseTo(2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('+12,054,100.55', 'en-CA')).toBeCloseTo(12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Automatically)(Range: [0, 1]) It should return a possible decimal literal when given an
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-CA', 0, 0, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-CA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-CA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -58,7 +61,10 @@ describe('Testing `getNumber` with `en-CA` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-CA', 1, 100, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-CA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-CA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -66,7 +72,10 @@ describe('Testing `getNumber` with `en-CA` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-CA', 100, 1000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-CA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-CA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -74,7 +83,10 @@ describe('Testing `getNumber` with `en-CA` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-CA', 1000, 10000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-CA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-CA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -82,7 +94,10 @@ describe('Testing `getNumber` with `en-CA` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-CA', 10000, 100000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-CA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-CA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -90,7 +105,10 @@ describe('Testing `getNumber` with `en-CA` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-CA', 100000, 1000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-CA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-CA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -98,7 +116,10 @@ describe('Testing `getNumber` with `en-CA` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-CA', 1000000, 10000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-CA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-CA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -106,7 +127,10 @@ describe('Testing `getNumber` with `en-CA` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-CA', 10000000, 100000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-CA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-CA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -114,7 +138,10 @@ describe('Testing `getNumber` with `en-CA` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-CA', 100000000, 1000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-CA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-CA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -122,7 +149,10 @@ describe('Testing `getNumber` with `en-CA` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-CA', 1000000000, 10000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-CA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-CA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -130,7 +160,10 @@ describe('Testing `getNumber` with `en-CA` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-CA', 10000000000, 100000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-CA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-CA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -138,7 +171,10 @@ describe('Testing `getNumber` with `en-CA` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-CA', 100000000000, 1000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-CA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-CA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -146,7 +182,10 @@ describe('Testing `getNumber` with `en-CA` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-CA', 1000000000000, 10000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-CA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-CA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -154,7 +193,10 @@ describe('Testing `getNumber` with `en-CA` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-CA', 10000000000000, 100000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-CA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-CA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 });
@@ -162,28 +204,31 @@ describe('Testing `getNumber` with `en-CA` locale on positive numbers', () => {
 describe('Testing `getNumber` with `en-CA` locale on negative numbers', () => {
   test(`(Manually) It should return a negative decimal literal when given a
   negative string representation`, () => {
-    expect(getNumber('-0.0', 'en-CA')).toBeCloseTo(-0.0, 20);
-    expect(getNumber('-0.45', 'en-CA')).toBeCloseTo(-0.45, 20);
-    expect(getNumber('-0.3', 'en-CA')).toBeCloseTo(-0.3, 20);
-    expect(getNumber('-0.243225', 'en-CA')).toBeCloseTo(-0.243225, 20);
-    expect(getNumber('-200', 'en-CA')).toBeCloseTo(-200, 20);
-    expect(getNumber('-200.45', 'en-CA')).toBeCloseTo(-200.45, 20);
-    expect(getNumber('-873.00', 'en-CA')).toBeCloseTo(-873.0, 20);
-    expect(getNumber('-2,050', 'en-CA')).toBeCloseTo(-2050, 20);
-    expect(getNumber('-2,000.30', 'en-CA')).toBeCloseTo(-2000.3, 20);
-    expect(getNumber('-2,342.0', 'en-CA')).toBeCloseTo(-2342.0, 20);
-    expect(getNumber('-20,000', 'en-CA')).toBeCloseTo(-20000, 20);
-    expect(getNumber('-20,000.34', 'en-CA')).toBeCloseTo(-20000.34, 20);
-    expect(getNumber('-200,000', 'en-CA')).toBeCloseTo(-200000, 20);
-    expect(getNumber('-2,000,000', 'en-CA')).toBeCloseTo(-2000000, 20);
-    expect(getNumber('-12,054,100.55', 'en-CA')).toBeCloseTo(-12054100.55, 20);
+    expect(getNumber('-0.0', 'en-CA')).toBeCloseTo(-0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-0.45', 'en-CA')).toBeCloseTo(-0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('-0.3', 'en-CA')).toBeCloseTo(-0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('-0.243225', 'en-CA')).toBeCloseTo(-0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('-200', 'en-CA')).toBeCloseTo(-200, supportedNumberOfFractionDigits);
+    expect(getNumber('-200.45', 'en-CA')).toBeCloseTo(-200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('-873.00', 'en-CA')).toBeCloseTo(-873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-2,050', 'en-CA')).toBeCloseTo(-2050, supportedNumberOfFractionDigits);
+    expect(getNumber('-2,000.30', 'en-CA')).toBeCloseTo(-2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('-2,342.0', 'en-CA')).toBeCloseTo(-2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-20,000', 'en-CA')).toBeCloseTo(-20000, supportedNumberOfFractionDigits);
+    expect(getNumber('-20,000.34', 'en-CA')).toBeCloseTo(-20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('-200,000', 'en-CA')).toBeCloseTo(-200000, supportedNumberOfFractionDigits);
+    expect(getNumber('-2,000,000', 'en-CA')).toBeCloseTo(-2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('-12,054,100.55', 'en-CA')).toBeCloseTo(-12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Automatically)(Range: [-1, 0]) It should return a possible decimal literal when given an
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-CA', 0, -2, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-CA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-CA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -191,7 +236,10 @@ describe('Testing `getNumber` with `en-CA` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-CA', -100, -1, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-CA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-CA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -199,7 +247,10 @@ describe('Testing `getNumber` with `en-CA` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-CA', -1000, -100, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-CA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-CA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -207,7 +258,10 @@ describe('Testing `getNumber` with `en-CA` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-CA', -10000, -1000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-CA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-CA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -215,7 +269,10 @@ describe('Testing `getNumber` with `en-CA` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-CA', -100000, -10000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-CA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-CA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -223,7 +280,10 @@ describe('Testing `getNumber` with `en-CA` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-CA', -1000000, -100000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-CA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-CA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -231,7 +291,10 @@ describe('Testing `getNumber` with `en-CA` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-CA', -10000000, -1000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-CA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-CA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -239,7 +302,10 @@ describe('Testing `getNumber` with `en-CA` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-CA', -100000000, -10000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-CA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-CA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -247,7 +313,10 @@ describe('Testing `getNumber` with `en-CA` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-CA', -1000000000, -100000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-CA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-CA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -255,7 +324,10 @@ describe('Testing `getNumber` with `en-CA` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-CA', -10000000000, -1000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-CA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-CA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -263,7 +335,10 @@ describe('Testing `getNumber` with `en-CA` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-CA', -100000000000, -10000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-CA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-CA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -271,7 +346,10 @@ describe('Testing `getNumber` with `en-CA` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-CA', -1000000000000, -100000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-CA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-CA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -279,7 +357,10 @@ describe('Testing `getNumber` with `en-CA` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-CA', -10000000000000, -1000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-CA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-CA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 });

--- a/src/get-number/specs/get-number.en-gb.spec.js
+++ b/src/get-number/specs/get-number.en-gb.spec.js
@@ -1,5 +1,5 @@
 const getNumber = require('../get-number');
-const testCaseGenerator = require('./test-case-generator');
+const { testCaseGenerator, supportedNumberOfFractionDigits } = require('./test-case-generator');
 
 beforeEach(() => {
   // Making sure the `console.error` implementation is empty
@@ -10,47 +10,47 @@ beforeEach(() => {
 describe('Testing `getNumber` with `en-GB` locale on positive numbers', () => {
   test(`(Manually) It should return a positive decimal literal when given an 
   implicitly positive string representation`, () => {
-    expect(getNumber('0.0', 'en-GB')).toBeCloseTo(0.0, 20);
-    expect(getNumber('0.45', 'en-GB')).toBeCloseTo(0.45, 20);
-    expect(getNumber('0.3', 'en-GB')).toBeCloseTo(0.3, 20);
-    expect(getNumber('0.243225', 'en-GB')).toBeCloseTo(0.243225, 20);
-    expect(getNumber('200', 'en-GB')).toBeCloseTo(200, 20);
-    expect(getNumber('200.45', 'en-GB')).toBeCloseTo(200.45, 20);
-    expect(getNumber('873.00', 'en-GB')).toBeCloseTo(873.0, 20);
-    expect(getNumber('2,050', 'en-GB')).toBeCloseTo(2050, 20);
-    expect(getNumber('2,000.30', 'en-GB')).toBeCloseTo(2000.3, 20);
-    expect(getNumber('2,342.0', 'en-GB')).toBeCloseTo(2342.0, 20);
-    expect(getNumber('20,000', 'en-GB')).toBeCloseTo(20000, 20);
-    expect(getNumber('20,000.34', 'en-GB')).toBeCloseTo(20000.34, 20);
-    expect(getNumber('200,000', 'en-GB')).toBeCloseTo(200000, 20);
-    expect(getNumber('2,000,000', 'en-GB')).toBeCloseTo(2000000, 20);
-    expect(getNumber('12,054,100.55', 'en-GB')).toBeCloseTo(12054100.55, 20);
+    expect(getNumber('0.0', 'en-GB')).toBeCloseTo(0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('0.45', 'en-GB')).toBeCloseTo(0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('0.3', 'en-GB')).toBeCloseTo(0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('0.243225', 'en-GB')).toBeCloseTo(0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('200', 'en-GB')).toBeCloseTo(200, supportedNumberOfFractionDigits);
+    expect(getNumber('200.45', 'en-GB')).toBeCloseTo(200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('873.00', 'en-GB')).toBeCloseTo(873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('2,050', 'en-GB')).toBeCloseTo(2050, supportedNumberOfFractionDigits);
+    expect(getNumber('2,000.30', 'en-GB')).toBeCloseTo(2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('2,342.0', 'en-GB')).toBeCloseTo(2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('20,000', 'en-GB')).toBeCloseTo(20000, supportedNumberOfFractionDigits);
+    expect(getNumber('20,000.34', 'en-GB')).toBeCloseTo(20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('200,000', 'en-GB')).toBeCloseTo(200000, supportedNumberOfFractionDigits);
+    expect(getNumber('2,000,000', 'en-GB')).toBeCloseTo(2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('12,054,100.55', 'en-GB')).toBeCloseTo(12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Manually) It should return a positive decimal literal when given an 
   explicitly positive string representation`, () => {
-    expect(getNumber('+0.0', 'en-GB')).toBeCloseTo(0.0, 20);
-    expect(getNumber('+0.45', 'en-GB')).toBeCloseTo(0.45, 20);
-    expect(getNumber('+0.3', 'en-GB')).toBeCloseTo(0.3, 20);
-    expect(getNumber('+0.243225', 'en-GB')).toBeCloseTo(0.243225, 20);
-    expect(getNumber('+200', 'en-GB')).toBeCloseTo(200, 20);
-    expect(getNumber('+200.45', 'en-GB')).toBeCloseTo(200.45, 20);
-    expect(getNumber('+873.00', 'en-GB')).toBeCloseTo(873.0, 20);
-    expect(getNumber('+2,050', 'en-GB')).toBeCloseTo(2050, 20);
-    expect(getNumber('+2,000.30', 'en-GB')).toBeCloseTo(2000.3, 20);
-    expect(getNumber('+2,342.0', 'en-GB')).toBeCloseTo(2342.0, 20);
-    expect(getNumber('+20,000', 'en-GB')).toBeCloseTo(20000, 20);
-    expect(getNumber('+20,000.34', 'en-GB')).toBeCloseTo(20000.34, 20);
-    expect(getNumber('+200,000', 'en-GB')).toBeCloseTo(200000, 20);
-    expect(getNumber('+2,000,000', 'en-GB')).toBeCloseTo(2000000, 20);
-    expect(getNumber('+12,054,100.55', 'en-GB')).toBeCloseTo(12054100.55, 20);
+    expect(getNumber('+0.0', 'en-GB')).toBeCloseTo(0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+0.45', 'en-GB')).toBeCloseTo(0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('+0.3', 'en-GB')).toBeCloseTo(0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('+0.243225', 'en-GB')).toBeCloseTo(0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('+200', 'en-GB')).toBeCloseTo(200, supportedNumberOfFractionDigits);
+    expect(getNumber('+200.45', 'en-GB')).toBeCloseTo(200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('+873.00', 'en-GB')).toBeCloseTo(873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+2,050', 'en-GB')).toBeCloseTo(2050, supportedNumberOfFractionDigits);
+    expect(getNumber('+2,000.30', 'en-GB')).toBeCloseTo(2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('+2,342.0', 'en-GB')).toBeCloseTo(2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+20,000', 'en-GB')).toBeCloseTo(20000, supportedNumberOfFractionDigits);
+    expect(getNumber('+20,000.34', 'en-GB')).toBeCloseTo(20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('+200,000', 'en-GB')).toBeCloseTo(200000, supportedNumberOfFractionDigits);
+    expect(getNumber('+2,000,000', 'en-GB')).toBeCloseTo(2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('+12,054,100.55', 'en-GB')).toBeCloseTo(12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Automatically)(Range: [0, 1]) It should return a possible decimal literal when given an
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-GB', 0, 0, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-GB')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-GB')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -58,7 +58,7 @@ describe('Testing `getNumber` with `en-GB` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-GB', 1, 100, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-GB')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-GB')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -66,7 +66,7 @@ describe('Testing `getNumber` with `en-GB` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-GB', 100, 1000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-GB')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-GB')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -74,7 +74,7 @@ describe('Testing `getNumber` with `en-GB` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-GB', 1000, 10000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-GB')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-GB')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -82,7 +82,7 @@ describe('Testing `getNumber` with `en-GB` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-GB', 10000, 100000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-GB')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-GB')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -90,7 +90,7 @@ describe('Testing `getNumber` with `en-GB` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-GB', 100000, 1000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-GB')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-GB')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -98,7 +98,7 @@ describe('Testing `getNumber` with `en-GB` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-GB', 1000000, 10000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-GB')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-GB')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -106,7 +106,7 @@ describe('Testing `getNumber` with `en-GB` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-GB', 10000000, 100000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-GB')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-GB')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -114,7 +114,7 @@ describe('Testing `getNumber` with `en-GB` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-GB', 100000000, 1000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-GB')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-GB')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -122,7 +122,7 @@ describe('Testing `getNumber` with `en-GB` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-GB', 1000000000, 10000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-GB')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-GB')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -130,7 +130,7 @@ describe('Testing `getNumber` with `en-GB` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-GB', 10000000000, 100000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-GB')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-GB')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -138,7 +138,7 @@ describe('Testing `getNumber` with `en-GB` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-GB', 100000000000, 1000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-GB')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-GB')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -146,7 +146,7 @@ describe('Testing `getNumber` with `en-GB` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-GB', 1000000000000, 10000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-GB')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-GB')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -154,7 +154,7 @@ describe('Testing `getNumber` with `en-GB` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-GB', 10000000000000, 100000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-GB')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-GB')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 });
@@ -162,28 +162,28 @@ describe('Testing `getNumber` with `en-GB` locale on positive numbers', () => {
 describe('Testing `getNumber` with `en-GB` locale on negative numbers', () => {
   test(`(Manually) It should return a negative decimal literal when given a
   negative string representation`, () => {
-    expect(getNumber('-0.0', 'en-GB')).toBeCloseTo(-0.0, 20);
-    expect(getNumber('-0.45', 'en-GB')).toBeCloseTo(-0.45, 20);
-    expect(getNumber('-0.3', 'en-GB')).toBeCloseTo(-0.3, 20);
-    expect(getNumber('-0.243225', 'en-GB')).toBeCloseTo(-0.243225, 20);
-    expect(getNumber('-200', 'en-GB')).toBeCloseTo(-200, 20);
-    expect(getNumber('-200.45', 'en-GB')).toBeCloseTo(-200.45, 20);
-    expect(getNumber('-873.00', 'en-GB')).toBeCloseTo(-873.0, 20);
-    expect(getNumber('-2,050', 'en-GB')).toBeCloseTo(-2050, 20);
-    expect(getNumber('-2,000.30', 'en-GB')).toBeCloseTo(-2000.3, 20);
-    expect(getNumber('-2,342.0', 'en-GB')).toBeCloseTo(-2342.0, 20);
-    expect(getNumber('-20,000', 'en-GB')).toBeCloseTo(-20000, 20);
-    expect(getNumber('-20,000.34', 'en-GB')).toBeCloseTo(-20000.34, 20);
-    expect(getNumber('-200,000', 'en-GB')).toBeCloseTo(-200000, 20);
-    expect(getNumber('-2,000,000', 'en-GB')).toBeCloseTo(-2000000, 20);
-    expect(getNumber('-12,054,100.55', 'en-GB')).toBeCloseTo(-12054100.55, 20);
+    expect(getNumber('-0.0', 'en-GB')).toBeCloseTo(-0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-0.45', 'en-GB')).toBeCloseTo(-0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('-0.3', 'en-GB')).toBeCloseTo(-0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('-0.243225', 'en-GB')).toBeCloseTo(-0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('-200', 'en-GB')).toBeCloseTo(-200, supportedNumberOfFractionDigits);
+    expect(getNumber('-200.45', 'en-GB')).toBeCloseTo(-200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('-873.00', 'en-GB')).toBeCloseTo(-873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-2,050', 'en-GB')).toBeCloseTo(-2050, supportedNumberOfFractionDigits);
+    expect(getNumber('-2,000.30', 'en-GB')).toBeCloseTo(-2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('-2,342.0', 'en-GB')).toBeCloseTo(-2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-20,000', 'en-GB')).toBeCloseTo(-20000, supportedNumberOfFractionDigits);
+    expect(getNumber('-20,000.34', 'en-GB')).toBeCloseTo(-20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('-200,000', 'en-GB')).toBeCloseTo(-200000, supportedNumberOfFractionDigits);
+    expect(getNumber('-2,000,000', 'en-GB')).toBeCloseTo(-2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('-12,054,100.55', 'en-GB')).toBeCloseTo(-12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Automatically)(Range: [-1, 0]) It should return a possible decimal literal when given an
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-GB', 0, -2, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-GB')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-GB')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -191,7 +191,7 @@ describe('Testing `getNumber` with `en-GB` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-GB', -100, -1, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-GB')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-GB')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -199,7 +199,7 @@ describe('Testing `getNumber` with `en-GB` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-GB', -1000, -100, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-GB')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-GB')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -207,7 +207,7 @@ describe('Testing `getNumber` with `en-GB` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-GB', -10000, -1000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-GB')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-GB')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -215,7 +215,7 @@ describe('Testing `getNumber` with `en-GB` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-GB', -100000, -10000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-GB')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-GB')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -223,7 +223,7 @@ describe('Testing `getNumber` with `en-GB` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-GB', -1000000, -100000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-GB')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-GB')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -231,7 +231,7 @@ describe('Testing `getNumber` with `en-GB` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-GB', -10000000, -1000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-GB')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-GB')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -239,7 +239,7 @@ describe('Testing `getNumber` with `en-GB` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-GB', -100000000, -10000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-GB')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-GB')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -247,7 +247,7 @@ describe('Testing `getNumber` with `en-GB` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-GB', -1000000000, -100000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-GB')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-GB')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -255,7 +255,7 @@ describe('Testing `getNumber` with `en-GB` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-GB', -10000000000, -1000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-GB')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-GB')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -263,7 +263,7 @@ describe('Testing `getNumber` with `en-GB` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-GB', -100000000000, -10000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-GB')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-GB')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -271,7 +271,7 @@ describe('Testing `getNumber` with `en-GB` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-GB', -1000000000000, -100000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-GB')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-GB')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -279,7 +279,7 @@ describe('Testing `getNumber` with `en-GB` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-GB', -10000000000000, -1000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-GB')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-GB')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 });

--- a/src/get-number/specs/get-number.en-ie.spec.js
+++ b/src/get-number/specs/get-number.en-ie.spec.js
@@ -1,5 +1,5 @@
 const getNumber = require('../get-number');
-const testCaseGenerator = require('./test-case-generator');
+const { testCaseGenerator, supportedNumberOfFractionDigits } = require('./test-case-generator');
 
 beforeEach(() => {
   // Making sure the `console.error` implementation is empty
@@ -10,47 +10,50 @@ beforeEach(() => {
 describe('Testing `getNumber` with `en-IE` locale on positive numbers', () => {
   test(`(Manually) It should return a positive decimal literal when given an 
   implicitly positive string representation`, () => {
-    expect(getNumber('0.0', 'en-IE')).toBeCloseTo(0.0, 20);
-    expect(getNumber('0.45', 'en-IE')).toBeCloseTo(0.45, 20);
-    expect(getNumber('0.3', 'en-IE')).toBeCloseTo(0.3, 20);
-    expect(getNumber('0.243225', 'en-IE')).toBeCloseTo(0.243225, 20);
-    expect(getNumber('200', 'en-IE')).toBeCloseTo(200, 20);
-    expect(getNumber('200.45', 'en-IE')).toBeCloseTo(200.45, 20);
-    expect(getNumber('873.00', 'en-IE')).toBeCloseTo(873.0, 20);
-    expect(getNumber('2,050', 'en-IE')).toBeCloseTo(2050, 20);
-    expect(getNumber('2,000.30', 'en-IE')).toBeCloseTo(2000.3, 20);
-    expect(getNumber('2,342.0', 'en-IE')).toBeCloseTo(2342.0, 20);
-    expect(getNumber('20,000', 'en-IE')).toBeCloseTo(20000, 20);
-    expect(getNumber('20,000.34', 'en-IE')).toBeCloseTo(20000.34, 20);
-    expect(getNumber('200,000', 'en-IE')).toBeCloseTo(200000, 20);
-    expect(getNumber('2,000,000', 'en-IE')).toBeCloseTo(2000000, 20);
-    expect(getNumber('12,054,100.55', 'en-IE')).toBeCloseTo(12054100.55, 20);
+    expect(getNumber('0.0', 'en-IE')).toBeCloseTo(0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('0.45', 'en-IE')).toBeCloseTo(0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('0.3', 'en-IE')).toBeCloseTo(0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('0.243225', 'en-IE')).toBeCloseTo(0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('200', 'en-IE')).toBeCloseTo(200, supportedNumberOfFractionDigits);
+    expect(getNumber('200.45', 'en-IE')).toBeCloseTo(200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('873.00', 'en-IE')).toBeCloseTo(873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('2,050', 'en-IE')).toBeCloseTo(2050, supportedNumberOfFractionDigits);
+    expect(getNumber('2,000.30', 'en-IE')).toBeCloseTo(2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('2,342.0', 'en-IE')).toBeCloseTo(2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('20,000', 'en-IE')).toBeCloseTo(20000, supportedNumberOfFractionDigits);
+    expect(getNumber('20,000.34', 'en-IE')).toBeCloseTo(20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('200,000', 'en-IE')).toBeCloseTo(200000, supportedNumberOfFractionDigits);
+    expect(getNumber('2,000,000', 'en-IE')).toBeCloseTo(2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('12,054,100.55', 'en-IE')).toBeCloseTo(12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Manually) It should return a positive decimal literal when given an 
   explicitly positive string representation`, () => {
-    expect(getNumber('+0.0', 'en-IE')).toBeCloseTo(0.0, 20);
-    expect(getNumber('+0.45', 'en-IE')).toBeCloseTo(0.45, 20);
-    expect(getNumber('+0.3', 'en-IE')).toBeCloseTo(0.3, 20);
-    expect(getNumber('+0.243225', 'en-IE')).toBeCloseTo(0.243225, 20);
-    expect(getNumber('+200', 'en-IE')).toBeCloseTo(200, 20);
-    expect(getNumber('+200.45', 'en-IE')).toBeCloseTo(200.45, 20);
-    expect(getNumber('+873.00', 'en-IE')).toBeCloseTo(873.0, 20);
-    expect(getNumber('+2,050', 'en-IE')).toBeCloseTo(2050, 20);
-    expect(getNumber('+2,000.30', 'en-IE')).toBeCloseTo(2000.3, 20);
-    expect(getNumber('+2,342.0', 'en-IE')).toBeCloseTo(2342.0, 20);
-    expect(getNumber('+20,000', 'en-IE')).toBeCloseTo(20000, 20);
-    expect(getNumber('+20,000.34', 'en-IE')).toBeCloseTo(20000.34, 20);
-    expect(getNumber('+200,000', 'en-IE')).toBeCloseTo(200000, 20);
-    expect(getNumber('+2,000,000', 'en-IE')).toBeCloseTo(2000000, 20);
-    expect(getNumber('+12,054,100.55', 'en-IE')).toBeCloseTo(12054100.55, 20);
+    expect(getNumber('+0.0', 'en-IE')).toBeCloseTo(0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+0.45', 'en-IE')).toBeCloseTo(0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('+0.3', 'en-IE')).toBeCloseTo(0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('+0.243225', 'en-IE')).toBeCloseTo(0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('+200', 'en-IE')).toBeCloseTo(200, supportedNumberOfFractionDigits);
+    expect(getNumber('+200.45', 'en-IE')).toBeCloseTo(200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('+873.00', 'en-IE')).toBeCloseTo(873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+2,050', 'en-IE')).toBeCloseTo(2050, supportedNumberOfFractionDigits);
+    expect(getNumber('+2,000.30', 'en-IE')).toBeCloseTo(2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('+2,342.0', 'en-IE')).toBeCloseTo(2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+20,000', 'en-IE')).toBeCloseTo(20000, supportedNumberOfFractionDigits);
+    expect(getNumber('+20,000.34', 'en-IE')).toBeCloseTo(20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('+200,000', 'en-IE')).toBeCloseTo(200000, supportedNumberOfFractionDigits);
+    expect(getNumber('+2,000,000', 'en-IE')).toBeCloseTo(2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('+12,054,100.55', 'en-IE')).toBeCloseTo(12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Automatically)(Range: [0, 1]) It should return a possible decimal literal when given an
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-IE', 0, 0, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-IE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-IE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -58,7 +61,10 @@ describe('Testing `getNumber` with `en-IE` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-IE', 1, 100, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-IE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-IE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -66,7 +72,10 @@ describe('Testing `getNumber` with `en-IE` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-IE', 100, 1000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-IE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-IE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -74,7 +83,10 @@ describe('Testing `getNumber` with `en-IE` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-IE', 1000, 10000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-IE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-IE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -82,7 +94,10 @@ describe('Testing `getNumber` with `en-IE` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-IE', 10000, 100000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-IE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-IE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -90,7 +105,10 @@ describe('Testing `getNumber` with `en-IE` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-IE', 100000, 1000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-IE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-IE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -98,7 +116,10 @@ describe('Testing `getNumber` with `en-IE` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-IE', 1000000, 10000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-IE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-IE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -106,7 +127,10 @@ describe('Testing `getNumber` with `en-IE` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-IE', 10000000, 100000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-IE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-IE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -114,7 +138,10 @@ describe('Testing `getNumber` with `en-IE` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-IE', 100000000, 1000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-IE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-IE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -122,7 +149,10 @@ describe('Testing `getNumber` with `en-IE` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-IE', 1000000000, 10000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-IE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-IE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -130,7 +160,10 @@ describe('Testing `getNumber` with `en-IE` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-IE', 10000000000, 100000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-IE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-IE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -138,7 +171,10 @@ describe('Testing `getNumber` with `en-IE` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-IE', 100000000000, 1000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-IE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-IE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -146,7 +182,10 @@ describe('Testing `getNumber` with `en-IE` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-IE', 1000000000000, 10000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-IE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-IE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -154,7 +193,10 @@ describe('Testing `getNumber` with `en-IE` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-IE', 10000000000000, 100000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-IE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-IE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 });
@@ -162,28 +204,31 @@ describe('Testing `getNumber` with `en-IE` locale on positive numbers', () => {
 describe('Testing `getNumber` with `en-IE` locale on negative numbers', () => {
   test(`(Manually) It should return a negative decimal literal when given a
   negative string representation`, () => {
-    expect(getNumber('-0.0', 'en-IE')).toBeCloseTo(-0.0, 20);
-    expect(getNumber('-0.45', 'en-IE')).toBeCloseTo(-0.45, 20);
-    expect(getNumber('-0.3', 'en-IE')).toBeCloseTo(-0.3, 20);
-    expect(getNumber('-0.243225', 'en-IE')).toBeCloseTo(-0.243225, 20);
-    expect(getNumber('-200', 'en-IE')).toBeCloseTo(-200, 20);
-    expect(getNumber('-200.45', 'en-IE')).toBeCloseTo(-200.45, 20);
-    expect(getNumber('-873.00', 'en-IE')).toBeCloseTo(-873.0, 20);
-    expect(getNumber('-2,050', 'en-IE')).toBeCloseTo(-2050, 20);
-    expect(getNumber('-2,000.30', 'en-IE')).toBeCloseTo(-2000.3, 20);
-    expect(getNumber('-2,342.0', 'en-IE')).toBeCloseTo(-2342.0, 20);
-    expect(getNumber('-20,000', 'en-IE')).toBeCloseTo(-20000, 20);
-    expect(getNumber('-20,000.34', 'en-IE')).toBeCloseTo(-20000.34, 20);
-    expect(getNumber('-200,000', 'en-IE')).toBeCloseTo(-200000, 20);
-    expect(getNumber('-2,000,000', 'en-IE')).toBeCloseTo(-2000000, 20);
-    expect(getNumber('-12,054,100.55', 'en-IE')).toBeCloseTo(-12054100.55, 20);
+    expect(getNumber('-0.0', 'en-IE')).toBeCloseTo(-0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-0.45', 'en-IE')).toBeCloseTo(-0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('-0.3', 'en-IE')).toBeCloseTo(-0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('-0.243225', 'en-IE')).toBeCloseTo(-0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('-200', 'en-IE')).toBeCloseTo(-200, supportedNumberOfFractionDigits);
+    expect(getNumber('-200.45', 'en-IE')).toBeCloseTo(-200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('-873.00', 'en-IE')).toBeCloseTo(-873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-2,050', 'en-IE')).toBeCloseTo(-2050, supportedNumberOfFractionDigits);
+    expect(getNumber('-2,000.30', 'en-IE')).toBeCloseTo(-2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('-2,342.0', 'en-IE')).toBeCloseTo(-2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-20,000', 'en-IE')).toBeCloseTo(-20000, supportedNumberOfFractionDigits);
+    expect(getNumber('-20,000.34', 'en-IE')).toBeCloseTo(-20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('-200,000', 'en-IE')).toBeCloseTo(-200000, supportedNumberOfFractionDigits);
+    expect(getNumber('-2,000,000', 'en-IE')).toBeCloseTo(-2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('-12,054,100.55', 'en-IE')).toBeCloseTo(-12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Automatically)(Range: [-1, 0]) It should return a possible decimal literal when given an
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-IE', 0, -2, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-IE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-IE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -191,7 +236,10 @@ describe('Testing `getNumber` with `en-IE` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-IE', -100, -1, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-IE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-IE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -199,7 +247,10 @@ describe('Testing `getNumber` with `en-IE` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-IE', -1000, -100, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-IE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-IE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -207,7 +258,10 @@ describe('Testing `getNumber` with `en-IE` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-IE', -10000, -1000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-IE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-IE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -215,7 +269,10 @@ describe('Testing `getNumber` with `en-IE` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-IE', -100000, -10000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-IE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-IE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -223,7 +280,10 @@ describe('Testing `getNumber` with `en-IE` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-IE', -1000000, -100000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-IE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-IE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -231,7 +291,10 @@ describe('Testing `getNumber` with `en-IE` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-IE', -10000000, -1000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-IE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-IE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -239,7 +302,10 @@ describe('Testing `getNumber` with `en-IE` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-IE', -100000000, -10000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-IE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-IE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -247,7 +313,10 @@ describe('Testing `getNumber` with `en-IE` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-IE', -1000000000, -100000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-IE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-IE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -255,7 +324,10 @@ describe('Testing `getNumber` with `en-IE` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-IE', -10000000000, -1000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-IE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-IE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -263,7 +335,10 @@ describe('Testing `getNumber` with `en-IE` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-IE', -100000000000, -10000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-IE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-IE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -271,7 +346,10 @@ describe('Testing `getNumber` with `en-IE` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-IE', -1000000000000, -100000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-IE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-IE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -279,7 +357,10 @@ describe('Testing `getNumber` with `en-IE` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-IE', -10000000000000, -1000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-IE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-IE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 });

--- a/src/get-number/specs/get-number.en-in.spec.js
+++ b/src/get-number/specs/get-number.en-in.spec.js
@@ -1,5 +1,5 @@
 const getNumber = require('../get-number');
-const testCaseGenerator = require('./test-case-generator');
+const { testCaseGenerator, supportedNumberOfFractionDigits } = require('./test-case-generator');
 
 beforeEach(() => {
   // Making sure the `console.error` implementation is empty
@@ -10,47 +10,50 @@ beforeEach(() => {
 describe('Testing `getNumber` with `en-IN` locale on positive numbers', () => {
   test(`(Manually) It should return a positive decimal literal when given an 
   implicitly positive string representation`, () => {
-    expect(getNumber('0.0', 'en-IN')).toBeCloseTo(0.0, 20);
-    expect(getNumber('0.45', 'en-IN')).toBeCloseTo(0.45, 20);
-    expect(getNumber('0.3', 'en-IN')).toBeCloseTo(0.3, 20);
-    expect(getNumber('0.243225', 'en-IN')).toBeCloseTo(0.243225, 20);
-    expect(getNumber('200', 'en-IN')).toBeCloseTo(200, 20);
-    expect(getNumber('200.45', 'en-IN')).toBeCloseTo(200.45, 20);
-    expect(getNumber('873.00', 'en-IN')).toBeCloseTo(873.0, 20);
-    expect(getNumber('2,050', 'en-IN')).toBeCloseTo(2050, 20);
-    expect(getNumber('2,000.30', 'en-IN')).toBeCloseTo(2000.3, 20);
-    expect(getNumber('2,342.0', 'en-IN')).toBeCloseTo(2342.0, 20);
-    expect(getNumber('20,000', 'en-IN')).toBeCloseTo(20000, 20);
-    expect(getNumber('20,000.34', 'en-IN')).toBeCloseTo(20000.34, 20);
-    expect(getNumber('2,00,000', 'en-IN')).toBeCloseTo(200000, 20);
-    expect(getNumber('20,00,000', 'en-IN')).toBeCloseTo(2000000, 20);
-    expect(getNumber('1,20,54,100.55', 'en-IN')).toBeCloseTo(12054100.55, 20);
+    expect(getNumber('0.0', 'en-IN')).toBeCloseTo(0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('0.45', 'en-IN')).toBeCloseTo(0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('0.3', 'en-IN')).toBeCloseTo(0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('0.243225', 'en-IN')).toBeCloseTo(0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('200', 'en-IN')).toBeCloseTo(200, supportedNumberOfFractionDigits);
+    expect(getNumber('200.45', 'en-IN')).toBeCloseTo(200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('873.00', 'en-IN')).toBeCloseTo(873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('2,050', 'en-IN')).toBeCloseTo(2050, supportedNumberOfFractionDigits);
+    expect(getNumber('2,000.30', 'en-IN')).toBeCloseTo(2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('2,342.0', 'en-IN')).toBeCloseTo(2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('20,000', 'en-IN')).toBeCloseTo(20000, supportedNumberOfFractionDigits);
+    expect(getNumber('20,000.34', 'en-IN')).toBeCloseTo(20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('2,00,000', 'en-IN')).toBeCloseTo(200000, supportedNumberOfFractionDigits);
+    expect(getNumber('20,00,000', 'en-IN')).toBeCloseTo(2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('1,20,54,100.55', 'en-IN')).toBeCloseTo(12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Manually) It should return a positive decimal literal when given an 
   explicitly positive string representation`, () => {
-    expect(getNumber('+0.0', 'en-IN')).toBeCloseTo(0.0, 20);
-    expect(getNumber('+0.45', 'en-IN')).toBeCloseTo(0.45, 20);
-    expect(getNumber('+0.3', 'en-IN')).toBeCloseTo(0.3, 20);
-    expect(getNumber('+0.243225', 'en-IN')).toBeCloseTo(0.243225, 20);
-    expect(getNumber('+200', 'en-IN')).toBeCloseTo(200, 20);
-    expect(getNumber('+200.45', 'en-IN')).toBeCloseTo(200.45, 20);
-    expect(getNumber('+873.00', 'en-IN')).toBeCloseTo(873.0, 20);
-    expect(getNumber('+2,050', 'en-IN')).toBeCloseTo(2050, 20);
-    expect(getNumber('+2,000.30', 'en-IN')).toBeCloseTo(2000.3, 20);
-    expect(getNumber('+2,342.0', 'en-IN')).toBeCloseTo(2342.0, 20);
-    expect(getNumber('+20,000', 'en-IN')).toBeCloseTo(20000, 20);
-    expect(getNumber('+20,000.34', 'en-IN')).toBeCloseTo(20000.34, 20);
-    expect(getNumber('+2,00,000', 'en-IN')).toBeCloseTo(200000, 20);
-    expect(getNumber('+20,00,000', 'en-IN')).toBeCloseTo(2000000, 20);
-    expect(getNumber('+1,20,54,100.55', 'en-IN')).toBeCloseTo(12054100.55, 20);
+    expect(getNumber('+0.0', 'en-IN')).toBeCloseTo(0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+0.45', 'en-IN')).toBeCloseTo(0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('+0.3', 'en-IN')).toBeCloseTo(0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('+0.243225', 'en-IN')).toBeCloseTo(0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('+200', 'en-IN')).toBeCloseTo(200, supportedNumberOfFractionDigits);
+    expect(getNumber('+200.45', 'en-IN')).toBeCloseTo(200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('+873.00', 'en-IN')).toBeCloseTo(873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+2,050', 'en-IN')).toBeCloseTo(2050, supportedNumberOfFractionDigits);
+    expect(getNumber('+2,000.30', 'en-IN')).toBeCloseTo(2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('+2,342.0', 'en-IN')).toBeCloseTo(2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+20,000', 'en-IN')).toBeCloseTo(20000, supportedNumberOfFractionDigits);
+    expect(getNumber('+20,000.34', 'en-IN')).toBeCloseTo(20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('+2,00,000', 'en-IN')).toBeCloseTo(200000, supportedNumberOfFractionDigits);
+    expect(getNumber('+20,00,000', 'en-IN')).toBeCloseTo(2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('+1,20,54,100.55', 'en-IN')).toBeCloseTo(12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Automatically)(Range: [0, 1]) It should return a possible decimal literal when given an
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-IN', 0, 0, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-IN')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-IN')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -58,7 +61,10 @@ describe('Testing `getNumber` with `en-IN` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-IN', 1, 100, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-IN')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-IN')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -66,7 +72,10 @@ describe('Testing `getNumber` with `en-IN` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-IN', 100, 1000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-IN')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-IN')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -74,7 +83,10 @@ describe('Testing `getNumber` with `en-IN` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-IN', 1000, 10000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-IN')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-IN')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -82,7 +94,10 @@ describe('Testing `getNumber` with `en-IN` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-IN', 10000, 100000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-IN')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-IN')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -90,7 +105,10 @@ describe('Testing `getNumber` with `en-IN` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-IN', 100000, 1000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-IN')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-IN')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -98,7 +116,10 @@ describe('Testing `getNumber` with `en-IN` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-IN', 1000000, 10000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-IN')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-IN')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -106,7 +127,10 @@ describe('Testing `getNumber` with `en-IN` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-IN', 10000000, 100000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-IN')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-IN')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -114,7 +138,10 @@ describe('Testing `getNumber` with `en-IN` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-IN', 100000000, 1000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-IN')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-IN')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -122,7 +149,10 @@ describe('Testing `getNumber` with `en-IN` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-IN', 1000000000, 10000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-IN')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-IN')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -130,7 +160,10 @@ describe('Testing `getNumber` with `en-IN` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-IN', 10000000000, 100000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-IN')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-IN')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -138,7 +171,10 @@ describe('Testing `getNumber` with `en-IN` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-IN', 100000000000, 1000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-IN')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-IN')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -146,7 +182,10 @@ describe('Testing `getNumber` with `en-IN` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-IN', 1000000000000, 10000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-IN')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-IN')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -154,7 +193,10 @@ describe('Testing `getNumber` with `en-IN` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-IN', 10000000000000, 100000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-IN')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-IN')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 });
@@ -162,28 +204,31 @@ describe('Testing `getNumber` with `en-IN` locale on positive numbers', () => {
 describe('Testing `getNumber` with `en-IN` locale on negative numbers', () => {
   test(`(Manually) It should return a negative decimal literal when given a
   negative string representation`, () => {
-    expect(getNumber('-0.0', 'en-IN')).toBeCloseTo(-0.0, 20);
-    expect(getNumber('-0.45', 'en-IN')).toBeCloseTo(-0.45, 20);
-    expect(getNumber('-0.3', 'en-IN')).toBeCloseTo(-0.3, 20);
-    expect(getNumber('-0.243225', 'en-IN')).toBeCloseTo(-0.243225, 20);
-    expect(getNumber('-200', 'en-IN')).toBeCloseTo(-200, 20);
-    expect(getNumber('-200.45', 'en-IN')).toBeCloseTo(-200.45, 20);
-    expect(getNumber('-873.00', 'en-IN')).toBeCloseTo(-873.0, 20);
-    expect(getNumber('-2,050', 'en-IN')).toBeCloseTo(-2050, 20);
-    expect(getNumber('-2,000.30', 'en-IN')).toBeCloseTo(-2000.3, 20);
-    expect(getNumber('-2,342.0', 'en-IN')).toBeCloseTo(-2342.0, 20);
-    expect(getNumber('-20,000', 'en-IN')).toBeCloseTo(-20000, 20);
-    expect(getNumber('-20,000.34', 'en-IN')).toBeCloseTo(-20000.34, 20);
-    expect(getNumber('-2,00,000', 'en-IN')).toBeCloseTo(-200000, 20);
-    expect(getNumber('-20,00,000', 'en-IN')).toBeCloseTo(-2000000, 20);
-    expect(getNumber('-1,20,54,100.55', 'en-IN')).toBeCloseTo(-12054100.55, 20);
+    expect(getNumber('-0.0', 'en-IN')).toBeCloseTo(-0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-0.45', 'en-IN')).toBeCloseTo(-0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('-0.3', 'en-IN')).toBeCloseTo(-0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('-0.243225', 'en-IN')).toBeCloseTo(-0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('-200', 'en-IN')).toBeCloseTo(-200, supportedNumberOfFractionDigits);
+    expect(getNumber('-200.45', 'en-IN')).toBeCloseTo(-200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('-873.00', 'en-IN')).toBeCloseTo(-873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-2,050', 'en-IN')).toBeCloseTo(-2050, supportedNumberOfFractionDigits);
+    expect(getNumber('-2,000.30', 'en-IN')).toBeCloseTo(-2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('-2,342.0', 'en-IN')).toBeCloseTo(-2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-20,000', 'en-IN')).toBeCloseTo(-20000, supportedNumberOfFractionDigits);
+    expect(getNumber('-20,000.34', 'en-IN')).toBeCloseTo(-20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('-2,00,000', 'en-IN')).toBeCloseTo(-200000, supportedNumberOfFractionDigits);
+    expect(getNumber('-20,00,000', 'en-IN')).toBeCloseTo(-2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('-1,20,54,100.55', 'en-IN')).toBeCloseTo(-12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Automatically)(Range: [-1, 0]) It should return a possible decimal literal when given an
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-IN', 0, -2, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-IN')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-IN')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -191,7 +236,10 @@ describe('Testing `getNumber` with `en-IN` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-IN', -100, -1, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-IN')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-IN')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -199,7 +247,10 @@ describe('Testing `getNumber` with `en-IN` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-IN', -1000, -100, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-IN')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-IN')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -207,7 +258,10 @@ describe('Testing `getNumber` with `en-IN` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-IN', -10000, -1000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-IN')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-IN')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -215,7 +269,10 @@ describe('Testing `getNumber` with `en-IN` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-IN', -100000, -10000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-IN')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-IN')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -223,7 +280,10 @@ describe('Testing `getNumber` with `en-IN` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-IN', -1000000, -100000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-IN')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-IN')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -231,7 +291,10 @@ describe('Testing `getNumber` with `en-IN` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-IN', -10000000, -1000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-IN')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-IN')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -239,7 +302,10 @@ describe('Testing `getNumber` with `en-IN` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-IN', -100000000, -10000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-IN')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-IN')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -247,7 +313,10 @@ describe('Testing `getNumber` with `en-IN` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-IN', -1000000000, -100000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-IN')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-IN')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -255,7 +324,10 @@ describe('Testing `getNumber` with `en-IN` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-IN', -10000000000, -1000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-IN')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-IN')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -263,7 +335,10 @@ describe('Testing `getNumber` with `en-IN` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-IN', -100000000000, -10000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-IN')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-IN')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -271,7 +346,10 @@ describe('Testing `getNumber` with `en-IN` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-IN', -1000000000000, -100000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-IN')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-IN')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -279,7 +357,10 @@ describe('Testing `getNumber` with `en-IN` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-IN', -10000000000000, -1000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-IN')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-IN')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 });

--- a/src/get-number/specs/get-number.en-nz.spec.js
+++ b/src/get-number/specs/get-number.en-nz.spec.js
@@ -1,5 +1,5 @@
 const getNumber = require('../get-number');
-const testCaseGenerator = require('./test-case-generator');
+const { testCaseGenerator, supportedNumberOfFractionDigits } = require('./test-case-generator');
 
 beforeEach(() => {
   // Making sure the `console.error` implementation is empty
@@ -10,47 +10,50 @@ beforeEach(() => {
 describe('Testing `getNumber` with `en-NZ` locale on positive numbers', () => {
   test(`(Manually) It should return a positive decimal literal when given an 
   implicitly positive string representation`, () => {
-    expect(getNumber('0.0', 'en-NZ')).toBeCloseTo(0.0, 20);
-    expect(getNumber('0.45', 'en-NZ')).toBeCloseTo(0.45, 20);
-    expect(getNumber('0.3', 'en-NZ')).toBeCloseTo(0.3, 20);
-    expect(getNumber('0.243225', 'en-NZ')).toBeCloseTo(0.243225, 20);
-    expect(getNumber('200', 'en-NZ')).toBeCloseTo(200, 20);
-    expect(getNumber('200.45', 'en-NZ')).toBeCloseTo(200.45, 20);
-    expect(getNumber('873.00', 'en-NZ')).toBeCloseTo(873.0, 20);
-    expect(getNumber('2,050', 'en-NZ')).toBeCloseTo(2050, 20);
-    expect(getNumber('2,000.30', 'en-NZ')).toBeCloseTo(2000.3, 20);
-    expect(getNumber('2,342.0', 'en-NZ')).toBeCloseTo(2342.0, 20);
-    expect(getNumber('20,000', 'en-NZ')).toBeCloseTo(20000, 20);
-    expect(getNumber('20,000.34', 'en-NZ')).toBeCloseTo(20000.34, 20);
-    expect(getNumber('200,000', 'en-NZ')).toBeCloseTo(200000, 20);
-    expect(getNumber('2,000,000', 'en-NZ')).toBeCloseTo(2000000, 20);
-    expect(getNumber('12,054,100.55', 'en-NZ')).toBeCloseTo(12054100.55, 20);
+    expect(getNumber('0.0', 'en-NZ')).toBeCloseTo(0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('0.45', 'en-NZ')).toBeCloseTo(0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('0.3', 'en-NZ')).toBeCloseTo(0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('0.243225', 'en-NZ')).toBeCloseTo(0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('200', 'en-NZ')).toBeCloseTo(200, supportedNumberOfFractionDigits);
+    expect(getNumber('200.45', 'en-NZ')).toBeCloseTo(200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('873.00', 'en-NZ')).toBeCloseTo(873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('2,050', 'en-NZ')).toBeCloseTo(2050, supportedNumberOfFractionDigits);
+    expect(getNumber('2,000.30', 'en-NZ')).toBeCloseTo(2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('2,342.0', 'en-NZ')).toBeCloseTo(2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('20,000', 'en-NZ')).toBeCloseTo(20000, supportedNumberOfFractionDigits);
+    expect(getNumber('20,000.34', 'en-NZ')).toBeCloseTo(20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('200,000', 'en-NZ')).toBeCloseTo(200000, supportedNumberOfFractionDigits);
+    expect(getNumber('2,000,000', 'en-NZ')).toBeCloseTo(2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('12,054,100.55', 'en-NZ')).toBeCloseTo(12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Manually) It should return a positive decimal literal when given an 
   explicitly positive string representation`, () => {
-    expect(getNumber('+0.0', 'en-NZ')).toBeCloseTo(0.0, 20);
-    expect(getNumber('+0.45', 'en-NZ')).toBeCloseTo(0.45, 20);
-    expect(getNumber('+0.3', 'en-NZ')).toBeCloseTo(0.3, 20);
-    expect(getNumber('+0.243225', 'en-NZ')).toBeCloseTo(0.243225, 20);
-    expect(getNumber('+200', 'en-NZ')).toBeCloseTo(200, 20);
-    expect(getNumber('+200.45', 'en-NZ')).toBeCloseTo(200.45, 20);
-    expect(getNumber('+873.00', 'en-NZ')).toBeCloseTo(873.0, 20);
-    expect(getNumber('+2,050', 'en-NZ')).toBeCloseTo(2050, 20);
-    expect(getNumber('+2,000.30', 'en-NZ')).toBeCloseTo(2000.3, 20);
-    expect(getNumber('+2,342.0', 'en-NZ')).toBeCloseTo(2342.0, 20);
-    expect(getNumber('+20,000', 'en-NZ')).toBeCloseTo(20000, 20);
-    expect(getNumber('+20,000.34', 'en-NZ')).toBeCloseTo(20000.34, 20);
-    expect(getNumber('+200,000', 'en-NZ')).toBeCloseTo(200000, 20);
-    expect(getNumber('+2,000,000', 'en-NZ')).toBeCloseTo(2000000, 20);
-    expect(getNumber('+12,054,100.55', 'en-NZ')).toBeCloseTo(12054100.55, 20);
+    expect(getNumber('+0.0', 'en-NZ')).toBeCloseTo(0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+0.45', 'en-NZ')).toBeCloseTo(0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('+0.3', 'en-NZ')).toBeCloseTo(0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('+0.243225', 'en-NZ')).toBeCloseTo(0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('+200', 'en-NZ')).toBeCloseTo(200, supportedNumberOfFractionDigits);
+    expect(getNumber('+200.45', 'en-NZ')).toBeCloseTo(200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('+873.00', 'en-NZ')).toBeCloseTo(873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+2,050', 'en-NZ')).toBeCloseTo(2050, supportedNumberOfFractionDigits);
+    expect(getNumber('+2,000.30', 'en-NZ')).toBeCloseTo(2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('+2,342.0', 'en-NZ')).toBeCloseTo(2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+20,000', 'en-NZ')).toBeCloseTo(20000, supportedNumberOfFractionDigits);
+    expect(getNumber('+20,000.34', 'en-NZ')).toBeCloseTo(20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('+200,000', 'en-NZ')).toBeCloseTo(200000, supportedNumberOfFractionDigits);
+    expect(getNumber('+2,000,000', 'en-NZ')).toBeCloseTo(2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('+12,054,100.55', 'en-NZ')).toBeCloseTo(12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Automatically)(Range: [0, 1]) It should return a possible decimal literal when given an
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-NZ', 0, 0, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-NZ')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-NZ')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -58,7 +61,10 @@ describe('Testing `getNumber` with `en-NZ` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-NZ', 1, 100, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-NZ')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-NZ')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -66,7 +72,10 @@ describe('Testing `getNumber` with `en-NZ` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-NZ', 100, 1000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-NZ')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-NZ')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -74,7 +83,10 @@ describe('Testing `getNumber` with `en-NZ` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-NZ', 1000, 10000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-NZ')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-NZ')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -82,7 +94,10 @@ describe('Testing `getNumber` with `en-NZ` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-NZ', 10000, 100000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-NZ')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-NZ')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -90,7 +105,10 @@ describe('Testing `getNumber` with `en-NZ` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-NZ', 100000, 1000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-NZ')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-NZ')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -98,7 +116,10 @@ describe('Testing `getNumber` with `en-NZ` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-NZ', 1000000, 10000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-NZ')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-NZ')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -106,7 +127,10 @@ describe('Testing `getNumber` with `en-NZ` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-NZ', 10000000, 100000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-NZ')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-NZ')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -114,7 +138,10 @@ describe('Testing `getNumber` with `en-NZ` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-NZ', 100000000, 1000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-NZ')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-NZ')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -122,7 +149,10 @@ describe('Testing `getNumber` with `en-NZ` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-NZ', 1000000000, 10000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-NZ')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-NZ')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -130,7 +160,10 @@ describe('Testing `getNumber` with `en-NZ` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-NZ', 10000000000, 100000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-NZ')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-NZ')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -138,7 +171,10 @@ describe('Testing `getNumber` with `en-NZ` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-NZ', 100000000000, 1000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-NZ')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-NZ')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -146,7 +182,10 @@ describe('Testing `getNumber` with `en-NZ` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-NZ', 1000000000000, 10000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-NZ')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-NZ')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -154,7 +193,10 @@ describe('Testing `getNumber` with `en-NZ` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-NZ', 10000000000000, 100000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-NZ')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-NZ')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 });
@@ -162,28 +204,31 @@ describe('Testing `getNumber` with `en-NZ` locale on positive numbers', () => {
 describe('Testing `getNumber` with `en-NZ` locale on negative numbers', () => {
   test(`(Manually) It should return a negative decimal literal when given a
   negative string representation`, () => {
-    expect(getNumber('-0.0', 'en-NZ')).toBeCloseTo(-0.0, 20);
-    expect(getNumber('-0.45', 'en-NZ')).toBeCloseTo(-0.45, 20);
-    expect(getNumber('-0.3', 'en-NZ')).toBeCloseTo(-0.3, 20);
-    expect(getNumber('-0.243225', 'en-NZ')).toBeCloseTo(-0.243225, 20);
-    expect(getNumber('-200', 'en-NZ')).toBeCloseTo(-200, 20);
-    expect(getNumber('-200.45', 'en-NZ')).toBeCloseTo(-200.45, 20);
-    expect(getNumber('-873.00', 'en-NZ')).toBeCloseTo(-873.0, 20);
-    expect(getNumber('-2,050', 'en-NZ')).toBeCloseTo(-2050, 20);
-    expect(getNumber('-2,000.30', 'en-NZ')).toBeCloseTo(-2000.3, 20);
-    expect(getNumber('-2,342.0', 'en-NZ')).toBeCloseTo(-2342.0, 20);
-    expect(getNumber('-20,000', 'en-NZ')).toBeCloseTo(-20000, 20);
-    expect(getNumber('-20,000.34', 'en-NZ')).toBeCloseTo(-20000.34, 20);
-    expect(getNumber('-200,000', 'en-NZ')).toBeCloseTo(-200000, 20);
-    expect(getNumber('-2,000,000', 'en-NZ')).toBeCloseTo(-2000000, 20);
-    expect(getNumber('-12,054,100.55', 'en-NZ')).toBeCloseTo(-12054100.55, 20);
+    expect(getNumber('-0.0', 'en-NZ')).toBeCloseTo(-0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-0.45', 'en-NZ')).toBeCloseTo(-0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('-0.3', 'en-NZ')).toBeCloseTo(-0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('-0.243225', 'en-NZ')).toBeCloseTo(-0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('-200', 'en-NZ')).toBeCloseTo(-200, supportedNumberOfFractionDigits);
+    expect(getNumber('-200.45', 'en-NZ')).toBeCloseTo(-200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('-873.00', 'en-NZ')).toBeCloseTo(-873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-2,050', 'en-NZ')).toBeCloseTo(-2050, supportedNumberOfFractionDigits);
+    expect(getNumber('-2,000.30', 'en-NZ')).toBeCloseTo(-2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('-2,342.0', 'en-NZ')).toBeCloseTo(-2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-20,000', 'en-NZ')).toBeCloseTo(-20000, supportedNumberOfFractionDigits);
+    expect(getNumber('-20,000.34', 'en-NZ')).toBeCloseTo(-20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('-200,000', 'en-NZ')).toBeCloseTo(-200000, supportedNumberOfFractionDigits);
+    expect(getNumber('-2,000,000', 'en-NZ')).toBeCloseTo(-2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('-12,054,100.55', 'en-NZ')).toBeCloseTo(-12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Automatically)(Range: [-1, 0]) It should return a possible decimal literal when given an
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-NZ', 0, -2, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-NZ')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-NZ')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -191,7 +236,10 @@ describe('Testing `getNumber` with `en-NZ` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-NZ', -100, -1, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-NZ')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-NZ')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -199,7 +247,10 @@ describe('Testing `getNumber` with `en-NZ` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-NZ', -1000, -100, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-NZ')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-NZ')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -207,7 +258,10 @@ describe('Testing `getNumber` with `en-NZ` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-NZ', -10000, -1000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-NZ')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-NZ')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -215,7 +269,10 @@ describe('Testing `getNumber` with `en-NZ` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-NZ', -100000, -10000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-NZ')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-NZ')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -223,7 +280,10 @@ describe('Testing `getNumber` with `en-NZ` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-NZ', -1000000, -100000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-NZ')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-NZ')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -231,7 +291,10 @@ describe('Testing `getNumber` with `en-NZ` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-NZ', -10000000, -1000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-NZ')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-NZ')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -239,7 +302,10 @@ describe('Testing `getNumber` with `en-NZ` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-NZ', -100000000, -10000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-NZ')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-NZ')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -247,7 +313,10 @@ describe('Testing `getNumber` with `en-NZ` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-NZ', -1000000000, -100000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-NZ')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-NZ')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -255,7 +324,10 @@ describe('Testing `getNumber` with `en-NZ` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-NZ', -10000000000, -1000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-NZ')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-NZ')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -263,7 +335,10 @@ describe('Testing `getNumber` with `en-NZ` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-NZ', -100000000000, -10000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-NZ')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-NZ')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -271,7 +346,10 @@ describe('Testing `getNumber` with `en-NZ` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-NZ', -1000000000000, -100000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-NZ')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-NZ')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -279,7 +357,10 @@ describe('Testing `getNumber` with `en-NZ` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-NZ', -10000000000000, -1000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-NZ')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-NZ')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 });

--- a/src/get-number/specs/get-number.en-us.spec.js
+++ b/src/get-number/specs/get-number.en-us.spec.js
@@ -1,5 +1,5 @@
 const getNumber = require('../get-number');
-const testCaseGenerator = require('./test-case-generator');
+const { testCaseGenerator, supportedNumberOfFractionDigits } = require('./test-case-generator');
 
 beforeEach(() => {
   // Making sure the `console.error` implementation is empty
@@ -10,47 +10,47 @@ beforeEach(() => {
 describe('Testing `getNumber` with `en-US` locale on positive numbers', () => {
   test(`(Manually) It should return a positive decimal literal when given an 
   implicitly positive string representation`, () => {
-    expect(getNumber('0.0', 'en-US')).toBeCloseTo(0.0, 20);
-    expect(getNumber('0.45', 'en-US')).toBeCloseTo(0.45, 20);
-    expect(getNumber('0.3', 'en-US')).toBeCloseTo(0.3, 20);
-    expect(getNumber('0.243225', 'en-US')).toBeCloseTo(0.243225, 20);
-    expect(getNumber('200', 'en-US')).toBeCloseTo(200, 20);
-    expect(getNumber('200.45', 'en-US')).toBeCloseTo(200.45, 20);
-    expect(getNumber('873.00', 'en-US')).toBeCloseTo(873.0, 20);
-    expect(getNumber('2,050', 'en-US')).toBeCloseTo(2050, 20);
-    expect(getNumber('2,000.30', 'en-US')).toBeCloseTo(2000.3, 20);
-    expect(getNumber('2,342.0', 'en-US')).toBeCloseTo(2342.0, 20);
-    expect(getNumber('20,000', 'en-US')).toBeCloseTo(20000, 20);
-    expect(getNumber('20,000.34', 'en-US')).toBeCloseTo(20000.34, 20);
-    expect(getNumber('200,000', 'en-US')).toBeCloseTo(200000, 20);
-    expect(getNumber('2,000,000', 'en-US')).toBeCloseTo(2000000, 20);
-    expect(getNumber('12,054,100.55', 'en-US')).toBeCloseTo(12054100.55, 20);
+    expect(getNumber('0.0', 'en-US')).toBeCloseTo(0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('0.45', 'en-US')).toBeCloseTo(0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('0.3', 'en-US')).toBeCloseTo(0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('0.243225', 'en-US')).toBeCloseTo(0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('200', 'en-US')).toBeCloseTo(200, supportedNumberOfFractionDigits);
+    expect(getNumber('200.45', 'en-US')).toBeCloseTo(200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('873.00', 'en-US')).toBeCloseTo(873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('2,050', 'en-US')).toBeCloseTo(2050, supportedNumberOfFractionDigits);
+    expect(getNumber('2,000.30', 'en-US')).toBeCloseTo(2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('2,342.0', 'en-US')).toBeCloseTo(2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('20,000', 'en-US')).toBeCloseTo(20000, supportedNumberOfFractionDigits);
+    expect(getNumber('20,000.34', 'en-US')).toBeCloseTo(20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('200,000', 'en-US')).toBeCloseTo(200000, supportedNumberOfFractionDigits);
+    expect(getNumber('2,000,000', 'en-US')).toBeCloseTo(2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('12,054,100.55', 'en-US')).toBeCloseTo(12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Manually) It should return a positive decimal literal when given an 
   explicitly positive string representation`, () => {
-    expect(getNumber('+0.0', 'en-US')).toBeCloseTo(0.0, 20);
-    expect(getNumber('+0.45', 'en-US')).toBeCloseTo(0.45, 20);
-    expect(getNumber('+0.3', 'en-US')).toBeCloseTo(0.3, 20);
-    expect(getNumber('+0.243225', 'en-US')).toBeCloseTo(0.243225, 20);
-    expect(getNumber('+200', 'en-US')).toBeCloseTo(200, 20);
-    expect(getNumber('+200.45', 'en-US')).toBeCloseTo(200.45, 20);
-    expect(getNumber('+873.00', 'en-US')).toBeCloseTo(873.0, 20);
-    expect(getNumber('+2,050', 'en-US')).toBeCloseTo(2050, 20);
-    expect(getNumber('+2,000.30', 'en-US')).toBeCloseTo(2000.3, 20);
-    expect(getNumber('+2,342.0', 'en-US')).toBeCloseTo(2342.0, 20);
-    expect(getNumber('+20,000', 'en-US')).toBeCloseTo(20000, 20);
-    expect(getNumber('+20,000.34', 'en-US')).toBeCloseTo(20000.34, 20);
-    expect(getNumber('+200,000', 'en-US')).toBeCloseTo(200000, 20);
-    expect(getNumber('+2,000,000', 'en-US')).toBeCloseTo(2000000, 20);
-    expect(getNumber('+12,054,100.55', 'en-US')).toBeCloseTo(12054100.55, 20);
+    expect(getNumber('+0.0', 'en-US')).toBeCloseTo(0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+0.45', 'en-US')).toBeCloseTo(0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('+0.3', 'en-US')).toBeCloseTo(0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('+0.243225', 'en-US')).toBeCloseTo(0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('+200', 'en-US')).toBeCloseTo(200, supportedNumberOfFractionDigits);
+    expect(getNumber('+200.45', 'en-US')).toBeCloseTo(200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('+873.00', 'en-US')).toBeCloseTo(873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+2,050', 'en-US')).toBeCloseTo(2050, supportedNumberOfFractionDigits);
+    expect(getNumber('+2,000.30', 'en-US')).toBeCloseTo(2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('+2,342.0', 'en-US')).toBeCloseTo(2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+20,000', 'en-US')).toBeCloseTo(20000, supportedNumberOfFractionDigits);
+    expect(getNumber('+20,000.34', 'en-US')).toBeCloseTo(20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('+200,000', 'en-US')).toBeCloseTo(200000, supportedNumberOfFractionDigits);
+    expect(getNumber('+2,000,000', 'en-US')).toBeCloseTo(2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('+12,054,100.55', 'en-US')).toBeCloseTo(12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Automatically)(Range: [0, 1]) It should return a possible decimal literal when given an
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-US', 0, 0, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-US')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-US')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -58,7 +58,7 @@ describe('Testing `getNumber` with `en-US` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-US', 1, 100, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-US')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-US')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -66,7 +66,7 @@ describe('Testing `getNumber` with `en-US` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-US', 100, 1000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-US')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-US')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -74,7 +74,7 @@ describe('Testing `getNumber` with `en-US` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-US', 1000, 10000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-US')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-US')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -82,7 +82,7 @@ describe('Testing `getNumber` with `en-US` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-US', 10000, 100000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-US')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-US')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -90,7 +90,7 @@ describe('Testing `getNumber` with `en-US` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-US', 100000, 1000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-US')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-US')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -98,7 +98,7 @@ describe('Testing `getNumber` with `en-US` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-US', 1000000, 10000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-US')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-US')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -106,7 +106,7 @@ describe('Testing `getNumber` with `en-US` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-US', 10000000, 100000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-US')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-US')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -114,7 +114,7 @@ describe('Testing `getNumber` with `en-US` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-US', 100000000, 1000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-US')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-US')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -122,7 +122,7 @@ describe('Testing `getNumber` with `en-US` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-US', 1000000000, 10000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-US')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-US')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -130,7 +130,7 @@ describe('Testing `getNumber` with `en-US` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-US', 10000000000, 100000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-US')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-US')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -138,7 +138,7 @@ describe('Testing `getNumber` with `en-US` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-US', 100000000000, 1000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-US')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-US')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -146,7 +146,7 @@ describe('Testing `getNumber` with `en-US` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-US', 1000000000000, 10000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-US')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-US')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -154,7 +154,7 @@ describe('Testing `getNumber` with `en-US` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-US', 10000000000000, 100000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-US')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-US')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 });
@@ -162,28 +162,28 @@ describe('Testing `getNumber` with `en-US` locale on positive numbers', () => {
 describe('Testing `getNumber` with `en-US` locale on negative numbers', () => {
   test(`(Manually) It should return a negative decimal literal when given a
   negative string representation`, () => {
-    expect(getNumber('-0.0', 'en-US')).toBeCloseTo(-0.0, 20);
-    expect(getNumber('-0.45', 'en-US')).toBeCloseTo(-0.45, 20);
-    expect(getNumber('-0.3', 'en-US')).toBeCloseTo(-0.3, 20);
-    expect(getNumber('-0.243225', 'en-US')).toBeCloseTo(-0.243225, 20);
-    expect(getNumber('-200', 'en-US')).toBeCloseTo(-200, 20);
-    expect(getNumber('-200.45', 'en-US')).toBeCloseTo(-200.45, 20);
-    expect(getNumber('-873.00', 'en-US')).toBeCloseTo(-873.0, 20);
-    expect(getNumber('-2,050', 'en-US')).toBeCloseTo(-2050, 20);
-    expect(getNumber('-2,000.30', 'en-US')).toBeCloseTo(-2000.3, 20);
-    expect(getNumber('-2,342.0', 'en-US')).toBeCloseTo(-2342.0, 20);
-    expect(getNumber('-20,000', 'en-US')).toBeCloseTo(-20000, 20);
-    expect(getNumber('-20,000.34', 'en-US')).toBeCloseTo(-20000.34, 20);
-    expect(getNumber('-200,000', 'en-US')).toBeCloseTo(-200000, 20);
-    expect(getNumber('-2,000,000', 'en-US')).toBeCloseTo(-2000000, 20);
-    expect(getNumber('-12,054,100.55', 'en-US')).toBeCloseTo(-12054100.55, 20);
+    expect(getNumber('-0.0', 'en-US')).toBeCloseTo(-0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-0.45', 'en-US')).toBeCloseTo(-0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('-0.3', 'en-US')).toBeCloseTo(-0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('-0.243225', 'en-US')).toBeCloseTo(-0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('-200', 'en-US')).toBeCloseTo(-200, supportedNumberOfFractionDigits);
+    expect(getNumber('-200.45', 'en-US')).toBeCloseTo(-200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('-873.00', 'en-US')).toBeCloseTo(-873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-2,050', 'en-US')).toBeCloseTo(-2050, supportedNumberOfFractionDigits);
+    expect(getNumber('-2,000.30', 'en-US')).toBeCloseTo(-2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('-2,342.0', 'en-US')).toBeCloseTo(-2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-20,000', 'en-US')).toBeCloseTo(-20000, supportedNumberOfFractionDigits);
+    expect(getNumber('-20,000.34', 'en-US')).toBeCloseTo(-20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('-200,000', 'en-US')).toBeCloseTo(-200000, supportedNumberOfFractionDigits);
+    expect(getNumber('-2,000,000', 'en-US')).toBeCloseTo(-2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('-12,054,100.55', 'en-US')).toBeCloseTo(-12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Automatically)(Range: [-1, 0]) It should return a possible decimal literal when given an
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-US', 0, -2, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-US')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-US')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -191,7 +191,7 @@ describe('Testing `getNumber` with `en-US` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-US', -100, -1, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-US')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-US')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -199,7 +199,7 @@ describe('Testing `getNumber` with `en-US` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-US', -1000, -100, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-US')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-US')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -207,7 +207,7 @@ describe('Testing `getNumber` with `en-US` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-US', -10000, -1000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-US')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-US')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -215,7 +215,7 @@ describe('Testing `getNumber` with `en-US` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-US', -100000, -10000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-US')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-US')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -223,7 +223,7 @@ describe('Testing `getNumber` with `en-US` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-US', -1000000, -100000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-US')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-US')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -231,7 +231,7 @@ describe('Testing `getNumber` with `en-US` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-US', -10000000, -1000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-US')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-US')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -239,7 +239,7 @@ describe('Testing `getNumber` with `en-US` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-US', -100000000, -10000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-US')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-US')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -247,7 +247,7 @@ describe('Testing `getNumber` with `en-US` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-US', -1000000000, -100000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-US')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-US')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -255,7 +255,7 @@ describe('Testing `getNumber` with `en-US` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-US', -10000000000, -1000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-US')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-US')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -263,7 +263,7 @@ describe('Testing `getNumber` with `en-US` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-US', -100000000000, -10000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-US')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-US')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -271,7 +271,7 @@ describe('Testing `getNumber` with `en-US` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-US', -1000000000000, -100000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-US')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-US')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -279,7 +279,7 @@ describe('Testing `getNumber` with `en-US` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-US', -10000000000000, -1000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-US')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-US')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 });

--- a/src/get-number/specs/get-number.en-za.spec.js
+++ b/src/get-number/specs/get-number.en-za.spec.js
@@ -1,5 +1,5 @@
 const getNumber = require('../get-number');
-const testCaseGenerator = require('./test-case-generator');
+const { testCaseGenerator, supportedNumberOfFractionDigits } = require('./test-case-generator');
 
 beforeEach(() => {
   // Making sure the `console.error` implementation is empty
@@ -10,47 +10,50 @@ beforeEach(() => {
 describe('Testing `getNumber` with `en-ZA` locale on positive numbers', () => {
   test(`(Manually) It should return a positive decimal literal when given an 
   implicitly positive string representation`, () => {
-    expect(getNumber('0,0', 'en-ZA')).toBeCloseTo(0.0, 20);
-    expect(getNumber('0,45', 'en-ZA')).toBeCloseTo(0.45, 20);
-    expect(getNumber('0,3', 'en-ZA')).toBeCloseTo(0.3, 20);
-    expect(getNumber('0,243225', 'en-ZA')).toBeCloseTo(0.243225, 20);
-    expect(getNumber('200', 'en-ZA')).toBeCloseTo(200, 20);
-    expect(getNumber('200,45', 'en-ZA')).toBeCloseTo(200.45, 20);
-    expect(getNumber('873,00', 'en-ZA')).toBeCloseTo(873.0, 20);
-    expect(getNumber('2 050', 'en-ZA')).toBeCloseTo(2050, 20);
-    expect(getNumber('2 000,30', 'en-ZA')).toBeCloseTo(2000.3, 20);
-    expect(getNumber('2 342,0', 'en-ZA')).toBeCloseTo(2342.0, 20);
-    expect(getNumber('20 000', 'en-ZA')).toBeCloseTo(20000, 20);
-    expect(getNumber('20 000,34', 'en-ZA')).toBeCloseTo(20000.34, 20);
-    expect(getNumber('200 000', 'en-ZA')).toBeCloseTo(200000, 20);
-    expect(getNumber('2 000 000', 'en-ZA')).toBeCloseTo(2000000, 20);
-    expect(getNumber('12 054 100,55', 'en-ZA')).toBeCloseTo(12054100.55, 20);
+    expect(getNumber('0,0', 'en-ZA')).toBeCloseTo(0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('0,45', 'en-ZA')).toBeCloseTo(0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('0,3', 'en-ZA')).toBeCloseTo(0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('0,243225', 'en-ZA')).toBeCloseTo(0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('200', 'en-ZA')).toBeCloseTo(200, supportedNumberOfFractionDigits);
+    expect(getNumber('200,45', 'en-ZA')).toBeCloseTo(200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('873,00', 'en-ZA')).toBeCloseTo(873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('2 050', 'en-ZA')).toBeCloseTo(2050, supportedNumberOfFractionDigits);
+    expect(getNumber('2 000,30', 'en-ZA')).toBeCloseTo(2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('2 342,0', 'en-ZA')).toBeCloseTo(2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('20 000', 'en-ZA')).toBeCloseTo(20000, supportedNumberOfFractionDigits);
+    expect(getNumber('20 000,34', 'en-ZA')).toBeCloseTo(20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('200 000', 'en-ZA')).toBeCloseTo(200000, supportedNumberOfFractionDigits);
+    expect(getNumber('2 000 000', 'en-ZA')).toBeCloseTo(2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('12 054 100,55', 'en-ZA')).toBeCloseTo(12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Manually) It should return a positive decimal literal when given an 
   explicitly positive string representation`, () => {
-    expect(getNumber('+0,0', 'en-ZA')).toBeCloseTo(0.0, 20);
-    expect(getNumber('+0,45', 'en-ZA')).toBeCloseTo(0.45, 20);
-    expect(getNumber('+0,3', 'en-ZA')).toBeCloseTo(0.3, 20);
-    expect(getNumber('+0,243225', 'en-ZA')).toBeCloseTo(0.243225, 20);
-    expect(getNumber('+200', 'en-ZA')).toBeCloseTo(200, 20);
-    expect(getNumber('+200,45', 'en-ZA')).toBeCloseTo(200.45, 20);
-    expect(getNumber('+873,00', 'en-ZA')).toBeCloseTo(873.0, 20);
-    expect(getNumber('+2 050', 'en-ZA')).toBeCloseTo(2050, 20);
-    expect(getNumber('+2 000,30', 'en-ZA')).toBeCloseTo(2000.3, 20);
-    expect(getNumber('+2 342,0', 'en-ZA')).toBeCloseTo(2342.0, 20);
-    expect(getNumber('+20 000', 'en-ZA')).toBeCloseTo(20000, 20);
-    expect(getNumber('+20 000,34', 'en-ZA')).toBeCloseTo(20000.34, 20);
-    expect(getNumber('+200 000', 'en-ZA')).toBeCloseTo(200000, 20);
-    expect(getNumber('+2 000 000', 'en-ZA')).toBeCloseTo(2000000, 20);
-    expect(getNumber('+12 054 100,55', 'en-ZA')).toBeCloseTo(12054100.55, 20);
+    expect(getNumber('+0,0', 'en-ZA')).toBeCloseTo(0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+0,45', 'en-ZA')).toBeCloseTo(0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('+0,3', 'en-ZA')).toBeCloseTo(0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('+0,243225', 'en-ZA')).toBeCloseTo(0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('+200', 'en-ZA')).toBeCloseTo(200, supportedNumberOfFractionDigits);
+    expect(getNumber('+200,45', 'en-ZA')).toBeCloseTo(200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('+873,00', 'en-ZA')).toBeCloseTo(873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+2 050', 'en-ZA')).toBeCloseTo(2050, supportedNumberOfFractionDigits);
+    expect(getNumber('+2 000,30', 'en-ZA')).toBeCloseTo(2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('+2 342,0', 'en-ZA')).toBeCloseTo(2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+20 000', 'en-ZA')).toBeCloseTo(20000, supportedNumberOfFractionDigits);
+    expect(getNumber('+20 000,34', 'en-ZA')).toBeCloseTo(20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('+200 000', 'en-ZA')).toBeCloseTo(200000, supportedNumberOfFractionDigits);
+    expect(getNumber('+2 000 000', 'en-ZA')).toBeCloseTo(2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('+12 054 100,55', 'en-ZA')).toBeCloseTo(12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Automatically)(Range: [0, 1]) It should return a possible decimal literal when given an
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-ZA', 0, 0, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-ZA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-ZA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -58,7 +61,10 @@ describe('Testing `getNumber` with `en-ZA` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-ZA', 1, 100, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-ZA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-ZA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -66,7 +72,10 @@ describe('Testing `getNumber` with `en-ZA` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-ZA', 100, 1000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-ZA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-ZA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -74,7 +83,10 @@ describe('Testing `getNumber` with `en-ZA` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-ZA', 1000, 10000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-ZA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-ZA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -82,7 +94,10 @@ describe('Testing `getNumber` with `en-ZA` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-ZA', 10000, 100000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-ZA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-ZA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -90,7 +105,10 @@ describe('Testing `getNumber` with `en-ZA` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-ZA', 100000, 1000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-ZA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-ZA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -98,7 +116,10 @@ describe('Testing `getNumber` with `en-ZA` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-ZA', 1000000, 10000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-ZA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-ZA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -106,7 +127,10 @@ describe('Testing `getNumber` with `en-ZA` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-ZA', 10000000, 100000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-ZA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-ZA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -114,7 +138,10 @@ describe('Testing `getNumber` with `en-ZA` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-ZA', 100000000, 1000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-ZA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-ZA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -122,7 +149,10 @@ describe('Testing `getNumber` with `en-ZA` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-ZA', 1000000000, 10000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-ZA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-ZA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -130,7 +160,10 @@ describe('Testing `getNumber` with `en-ZA` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-ZA', 10000000000, 100000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-ZA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-ZA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -138,7 +171,10 @@ describe('Testing `getNumber` with `en-ZA` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-ZA', 100000000000, 1000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-ZA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-ZA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -146,7 +182,10 @@ describe('Testing `getNumber` with `en-ZA` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-ZA', 1000000000000, 10000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-ZA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-ZA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -154,7 +193,10 @@ describe('Testing `getNumber` with `en-ZA` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en-ZA', 10000000000000, 100000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-ZA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-ZA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 });
@@ -162,28 +204,31 @@ describe('Testing `getNumber` with `en-ZA` locale on positive numbers', () => {
 describe('Testing `getNumber` with `en-ZA` locale on negative numbers', () => {
   test(`(Manually) It should return a negative decimal literal when given a
   negative string representation`, () => {
-    expect(getNumber('-0,0', 'en-ZA')).toBeCloseTo(-0.0, 20);
-    expect(getNumber('-0,45', 'en-ZA')).toBeCloseTo(-0.45, 20);
-    expect(getNumber('-0,3', 'en-ZA')).toBeCloseTo(-0.3, 20);
-    expect(getNumber('-0,243225', 'en-ZA')).toBeCloseTo(-0.243225, 20);
-    expect(getNumber('-200', 'en-ZA')).toBeCloseTo(-200, 20);
-    expect(getNumber('-200,45', 'en-ZA')).toBeCloseTo(-200.45, 20);
-    expect(getNumber('-873,00', 'en-ZA')).toBeCloseTo(-873.0, 20);
-    expect(getNumber('-2 050', 'en-ZA')).toBeCloseTo(-2050, 20);
-    expect(getNumber('-2 000,30', 'en-ZA')).toBeCloseTo(-2000.3, 20);
-    expect(getNumber('-2 342,0', 'en-ZA')).toBeCloseTo(-2342.0, 20);
-    expect(getNumber('-20 000', 'en-ZA')).toBeCloseTo(-20000, 20);
-    expect(getNumber('-20 000,34', 'en-ZA')).toBeCloseTo(-20000.34, 20);
-    expect(getNumber('-200 000', 'en-ZA')).toBeCloseTo(-200000, 20);
-    expect(getNumber('-2 000 000', 'en-ZA')).toBeCloseTo(-2000000, 20);
-    expect(getNumber('-12 054 100,55', 'en-ZA')).toBeCloseTo(-12054100.55, 20);
+    expect(getNumber('-0,0', 'en-ZA')).toBeCloseTo(-0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-0,45', 'en-ZA')).toBeCloseTo(-0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('-0,3', 'en-ZA')).toBeCloseTo(-0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('-0,243225', 'en-ZA')).toBeCloseTo(-0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('-200', 'en-ZA')).toBeCloseTo(-200, supportedNumberOfFractionDigits);
+    expect(getNumber('-200,45', 'en-ZA')).toBeCloseTo(-200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('-873,00', 'en-ZA')).toBeCloseTo(-873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-2 050', 'en-ZA')).toBeCloseTo(-2050, supportedNumberOfFractionDigits);
+    expect(getNumber('-2 000,30', 'en-ZA')).toBeCloseTo(-2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('-2 342,0', 'en-ZA')).toBeCloseTo(-2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-20 000', 'en-ZA')).toBeCloseTo(-20000, supportedNumberOfFractionDigits);
+    expect(getNumber('-20 000,34', 'en-ZA')).toBeCloseTo(-20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('-200 000', 'en-ZA')).toBeCloseTo(-200000, supportedNumberOfFractionDigits);
+    expect(getNumber('-2 000 000', 'en-ZA')).toBeCloseTo(-2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('-12 054 100,55', 'en-ZA')).toBeCloseTo(-12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Automatically)(Range: [-1, 0]) It should return a possible decimal literal when given an
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-ZA', 0, -2, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-ZA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-ZA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -191,7 +236,10 @@ describe('Testing `getNumber` with `en-ZA` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-ZA', -100, -1, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-ZA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-ZA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -199,7 +247,10 @@ describe('Testing `getNumber` with `en-ZA` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-ZA', -1000, -100, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-ZA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-ZA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -207,7 +258,10 @@ describe('Testing `getNumber` with `en-ZA` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-ZA', -10000, -1000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-ZA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-ZA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -215,7 +269,10 @@ describe('Testing `getNumber` with `en-ZA` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-ZA', -100000, -10000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-ZA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-ZA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -223,7 +280,10 @@ describe('Testing `getNumber` with `en-ZA` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-ZA', -1000000, -100000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-ZA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-ZA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -231,7 +291,10 @@ describe('Testing `getNumber` with `en-ZA` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-ZA', -10000000, -1000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-ZA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-ZA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -239,7 +302,10 @@ describe('Testing `getNumber` with `en-ZA` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-ZA', -100000000, -10000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-ZA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-ZA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -247,7 +313,10 @@ describe('Testing `getNumber` with `en-ZA` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-ZA', -1000000000, -100000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-ZA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-ZA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -255,7 +324,10 @@ describe('Testing `getNumber` with `en-ZA` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-ZA', -10000000000, -1000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-ZA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-ZA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -263,7 +335,10 @@ describe('Testing `getNumber` with `en-ZA` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-ZA', -100000000000, -10000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-ZA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-ZA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -271,7 +346,10 @@ describe('Testing `getNumber` with `en-ZA` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-ZA', -1000000000000, -100000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-ZA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-ZA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -279,7 +357,10 @@ describe('Testing `getNumber` with `en-ZA` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en-ZA', -10000000000000, -1000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en-ZA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en-ZA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 });

--- a/src/get-number/specs/get-number.en.spec.js
+++ b/src/get-number/specs/get-number.en.spec.js
@@ -1,5 +1,5 @@
 const getNumber = require('../get-number');
-const testCaseGenerator = require('./test-case-generator');
+const { testCaseGenerator, supportedNumberOfFractionDigits } = require('./test-case-generator');
 
 beforeEach(() => {
   // Making sure the `console.error` implementation is empty
@@ -10,47 +10,47 @@ beforeEach(() => {
 describe('Testing `getNumber` with `en` locale on positive numbers', () => {
   test(`(Manually) It should return a positive decimal literal when given an 
   implicitly positive string representation`, () => {
-    expect(getNumber('0.0', 'en')).toBeCloseTo(0.0, 20);
-    expect(getNumber('0.45', 'en')).toBeCloseTo(0.45, 20);
-    expect(getNumber('0.3', 'en')).toBeCloseTo(0.3, 20);
-    expect(getNumber('0.243225', 'en')).toBeCloseTo(0.243225, 20);
-    expect(getNumber('200', 'en')).toBeCloseTo(200, 20);
-    expect(getNumber('200.45', 'en')).toBeCloseTo(200.45, 20);
-    expect(getNumber('873.00', 'en')).toBeCloseTo(873.0, 20);
-    expect(getNumber('2,050', 'en')).toBeCloseTo(2050, 20);
-    expect(getNumber('2,000.30', 'en')).toBeCloseTo(2000.3, 20);
-    expect(getNumber('2,342.0', 'en')).toBeCloseTo(2342.0, 20);
-    expect(getNumber('20,000', 'en')).toBeCloseTo(20000, 20);
-    expect(getNumber('20,000.34', 'en')).toBeCloseTo(20000.34, 20);
-    expect(getNumber('200,000', 'en')).toBeCloseTo(200000, 20);
-    expect(getNumber('2,000,000', 'en')).toBeCloseTo(2000000, 20);
-    expect(getNumber('12,054,100.55', 'en')).toBeCloseTo(12054100.55, 20);
+    expect(getNumber('0.0', 'en')).toBeCloseTo(0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('0.45', 'en')).toBeCloseTo(0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('0.3', 'en')).toBeCloseTo(0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('0.243225', 'en')).toBeCloseTo(0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('200', 'en')).toBeCloseTo(200, supportedNumberOfFractionDigits);
+    expect(getNumber('200.45', 'en')).toBeCloseTo(200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('873.00', 'en')).toBeCloseTo(873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('2,050', 'en')).toBeCloseTo(2050, supportedNumberOfFractionDigits);
+    expect(getNumber('2,000.30', 'en')).toBeCloseTo(2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('2,342.0', 'en')).toBeCloseTo(2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('20,000', 'en')).toBeCloseTo(20000, supportedNumberOfFractionDigits);
+    expect(getNumber('20,000.34', 'en')).toBeCloseTo(20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('200,000', 'en')).toBeCloseTo(200000, supportedNumberOfFractionDigits);
+    expect(getNumber('2,000,000', 'en')).toBeCloseTo(2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('12,054,100.55', 'en')).toBeCloseTo(12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Manually) It should return a positive decimal literal when given an 
   explicitly positive string representation`, () => {
-    expect(getNumber('+0.0', 'en')).toBeCloseTo(0.0, 20);
-    expect(getNumber('+0.45', 'en')).toBeCloseTo(0.45, 20);
-    expect(getNumber('+0.3', 'en')).toBeCloseTo(0.3, 20);
-    expect(getNumber('+0.243225', 'en')).toBeCloseTo(0.243225, 20);
-    expect(getNumber('+200', 'en')).toBeCloseTo(200, 20);
-    expect(getNumber('+200.45', 'en')).toBeCloseTo(200.45, 20);
-    expect(getNumber('+873.00', 'en')).toBeCloseTo(873.0, 20);
-    expect(getNumber('+2,050', 'en')).toBeCloseTo(2050, 20);
-    expect(getNumber('+2,000.30', 'en')).toBeCloseTo(2000.3, 20);
-    expect(getNumber('+2,342.0', 'en')).toBeCloseTo(2342.0, 20);
-    expect(getNumber('+20,000', 'en')).toBeCloseTo(20000, 20);
-    expect(getNumber('+20,000.34', 'en')).toBeCloseTo(20000.34, 20);
-    expect(getNumber('+200,000', 'en')).toBeCloseTo(200000, 20);
-    expect(getNumber('+2,000,000', 'en')).toBeCloseTo(2000000, 20);
-    expect(getNumber('+12,054,100.55', 'en')).toBeCloseTo(12054100.55, 20);
+    expect(getNumber('+0.0', 'en')).toBeCloseTo(0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+0.45', 'en')).toBeCloseTo(0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('+0.3', 'en')).toBeCloseTo(0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('+0.243225', 'en')).toBeCloseTo(0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('+200', 'en')).toBeCloseTo(200, supportedNumberOfFractionDigits);
+    expect(getNumber('+200.45', 'en')).toBeCloseTo(200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('+873.00', 'en')).toBeCloseTo(873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+2,050', 'en')).toBeCloseTo(2050, supportedNumberOfFractionDigits);
+    expect(getNumber('+2,000.30', 'en')).toBeCloseTo(2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('+2,342.0', 'en')).toBeCloseTo(2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+20,000', 'en')).toBeCloseTo(20000, supportedNumberOfFractionDigits);
+    expect(getNumber('+20,000.34', 'en')).toBeCloseTo(20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('+200,000', 'en')).toBeCloseTo(200000, supportedNumberOfFractionDigits);
+    expect(getNumber('+2,000,000', 'en')).toBeCloseTo(2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('+12,054,100.55', 'en')).toBeCloseTo(12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Automatically)(Range: [0, 1]) It should return a possible decimal literal when given an
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en', 0, 0, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -58,7 +58,7 @@ describe('Testing `getNumber` with `en` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en', 1, 100, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -66,7 +66,7 @@ describe('Testing `getNumber` with `en` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en', 100, 1000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -74,7 +74,7 @@ describe('Testing `getNumber` with `en` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en', 1000, 10000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -82,7 +82,7 @@ describe('Testing `getNumber` with `en` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en', 10000, 100000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -90,7 +90,7 @@ describe('Testing `getNumber` with `en` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en', 100000, 1000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -98,7 +98,7 @@ describe('Testing `getNumber` with `en` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en', 1000000, 10000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -106,7 +106,7 @@ describe('Testing `getNumber` with `en` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en', 10000000, 100000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -114,7 +114,7 @@ describe('Testing `getNumber` with `en` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en', 100000000, 1000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -122,7 +122,7 @@ describe('Testing `getNumber` with `en` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en', 1000000000, 10000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -130,7 +130,7 @@ describe('Testing `getNumber` with `en` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en', 10000000000, 100000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -138,7 +138,7 @@ describe('Testing `getNumber` with `en` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en', 100000000000, 1000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -146,7 +146,7 @@ describe('Testing `getNumber` with `en` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en', 1000000000000, 10000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -154,7 +154,7 @@ describe('Testing `getNumber` with `en` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('en', 10000000000000, 100000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 });
@@ -162,28 +162,28 @@ describe('Testing `getNumber` with `en` locale on positive numbers', () => {
 describe('Testing `getNumber` with `en` locale on negative numbers', () => {
   test(`(Manually) It should return a negative decimal literal when given a
   negative string representation`, () => {
-    expect(getNumber('-0.0', 'en')).toBeCloseTo(-0.0, 20);
-    expect(getNumber('-0.45', 'en')).toBeCloseTo(-0.45, 20);
-    expect(getNumber('-0.3', 'en')).toBeCloseTo(-0.3, 20);
-    expect(getNumber('-0.243225', 'en')).toBeCloseTo(-0.243225, 20);
-    expect(getNumber('-200', 'en')).toBeCloseTo(-200, 20);
-    expect(getNumber('-200.45', 'en')).toBeCloseTo(-200.45, 20);
-    expect(getNumber('-873.00', 'en')).toBeCloseTo(-873.0, 20);
-    expect(getNumber('-2,050', 'en')).toBeCloseTo(-2050, 20);
-    expect(getNumber('-2,000.30', 'en')).toBeCloseTo(-2000.3, 20);
-    expect(getNumber('-2,342.0', 'en')).toBeCloseTo(-2342.0, 20);
-    expect(getNumber('-20,000', 'en')).toBeCloseTo(-20000, 20);
-    expect(getNumber('-20,000.34', 'en')).toBeCloseTo(-20000.34, 20);
-    expect(getNumber('-200,000', 'en')).toBeCloseTo(-200000, 20);
-    expect(getNumber('-2,000,000', 'en')).toBeCloseTo(-2000000, 20);
-    expect(getNumber('-12,054,100.55', 'en')).toBeCloseTo(-12054100.55, 20);
+    expect(getNumber('-0.0', 'en')).toBeCloseTo(-0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-0.45', 'en')).toBeCloseTo(-0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('-0.3', 'en')).toBeCloseTo(-0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('-0.243225', 'en')).toBeCloseTo(-0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('-200', 'en')).toBeCloseTo(-200, supportedNumberOfFractionDigits);
+    expect(getNumber('-200.45', 'en')).toBeCloseTo(-200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('-873.00', 'en')).toBeCloseTo(-873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-2,050', 'en')).toBeCloseTo(-2050, supportedNumberOfFractionDigits);
+    expect(getNumber('-2,000.30', 'en')).toBeCloseTo(-2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('-2,342.0', 'en')).toBeCloseTo(-2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-20,000', 'en')).toBeCloseTo(-20000, supportedNumberOfFractionDigits);
+    expect(getNumber('-20,000.34', 'en')).toBeCloseTo(-20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('-200,000', 'en')).toBeCloseTo(-200000, supportedNumberOfFractionDigits);
+    expect(getNumber('-2,000,000', 'en')).toBeCloseTo(-2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('-12,054,100.55', 'en')).toBeCloseTo(-12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Automatically)(Range: [-1, 0]) It should return a possible decimal literal when given an
   negative string representation`, () => {
     const testCases = testCaseGenerator('en', 0, -2, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -191,7 +191,7 @@ describe('Testing `getNumber` with `en` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en', -100, -1, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -199,7 +199,7 @@ describe('Testing `getNumber` with `en` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en', -1000, -100, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -207,7 +207,7 @@ describe('Testing `getNumber` with `en` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en', -10000, -1000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -215,7 +215,7 @@ describe('Testing `getNumber` with `en` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en', -100000, -10000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -223,7 +223,7 @@ describe('Testing `getNumber` with `en` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en', -1000000, -100000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -231,7 +231,7 @@ describe('Testing `getNumber` with `en` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en', -10000000, -1000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -239,7 +239,7 @@ describe('Testing `getNumber` with `en` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en', -100000000, -10000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -247,7 +247,7 @@ describe('Testing `getNumber` with `en` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en', -1000000000, -100000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -255,7 +255,7 @@ describe('Testing `getNumber` with `en` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en', -10000000000, -1000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -263,7 +263,7 @@ describe('Testing `getNumber` with `en` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en', -100000000000, -10000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -271,7 +271,7 @@ describe('Testing `getNumber` with `en` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en', -1000000000000, -100000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 
@@ -279,7 +279,7 @@ describe('Testing `getNumber` with `en` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('en', -10000000000000, -1000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'en')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'en')).toBeCloseTo(testCase.groundTruth, supportedNumberOfFractionDigits);
     });
   });
 });

--- a/src/get-number/specs/get-number.fr-be.spec.js
+++ b/src/get-number/specs/get-number.fr-be.spec.js
@@ -1,5 +1,5 @@
 const getNumber = require('../get-number');
-const testCaseGenerator = require('./test-case-generator');
+const { testCaseGenerator, supportedNumberOfFractionDigits } = require('./test-case-generator');
 
 beforeEach(() => {
   // Making sure the `console.error` implementation is empty
@@ -10,47 +10,50 @@ beforeEach(() => {
 describe('Testing `getNumber` with `fr-BE` locale on positive numbers', () => {
   test(`(Manually) It should return a positive decimal literal when given an 
   implicitly positive string representation`, () => {
-    expect(getNumber('0,0', 'fr-BE')).toBeCloseTo(0.0, 20);
-    expect(getNumber('0,45', 'fr-BE')).toBeCloseTo(0.45, 20);
-    expect(getNumber('0,3', 'fr-BE')).toBeCloseTo(0.3, 20);
-    expect(getNumber('0,243225', 'fr-BE')).toBeCloseTo(0.243225, 20);
-    expect(getNumber('200', 'fr-BE')).toBeCloseTo(200, 20);
-    expect(getNumber('200,45', 'fr-BE')).toBeCloseTo(200.45, 20);
-    expect(getNumber('873,00', 'fr-BE')).toBeCloseTo(873.0, 20);
-    expect(getNumber('2 050', 'fr-BE')).toBeCloseTo(2050, 20);
-    expect(getNumber('2 000,30', 'fr-BE')).toBeCloseTo(2000.3, 20);
-    expect(getNumber('2 342,0', 'fr-BE')).toBeCloseTo(2342.0, 20);
-    expect(getNumber('20 000', 'fr-BE')).toBeCloseTo(20000, 20);
-    expect(getNumber('20 000,34', 'fr-BE')).toBeCloseTo(20000.34, 20);
-    expect(getNumber('200 000', 'fr-BE')).toBeCloseTo(200000, 20);
-    expect(getNumber('2 000 000', 'fr-BE')).toBeCloseTo(2000000, 20);
-    expect(getNumber('12 054 100,55', 'fr-BE')).toBeCloseTo(12054100.55, 20);
+    expect(getNumber('0,0', 'fr-BE')).toBeCloseTo(0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('0,45', 'fr-BE')).toBeCloseTo(0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('0,3', 'fr-BE')).toBeCloseTo(0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('0,243225', 'fr-BE')).toBeCloseTo(0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('200', 'fr-BE')).toBeCloseTo(200, supportedNumberOfFractionDigits);
+    expect(getNumber('200,45', 'fr-BE')).toBeCloseTo(200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('873,00', 'fr-BE')).toBeCloseTo(873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('2 050', 'fr-BE')).toBeCloseTo(2050, supportedNumberOfFractionDigits);
+    expect(getNumber('2 000,30', 'fr-BE')).toBeCloseTo(2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('2 342,0', 'fr-BE')).toBeCloseTo(2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('20 000', 'fr-BE')).toBeCloseTo(20000, supportedNumberOfFractionDigits);
+    expect(getNumber('20 000,34', 'fr-BE')).toBeCloseTo(20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('200 000', 'fr-BE')).toBeCloseTo(200000, supportedNumberOfFractionDigits);
+    expect(getNumber('2 000 000', 'fr-BE')).toBeCloseTo(2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('12 054 100,55', 'fr-BE')).toBeCloseTo(12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Manually) It should return a positive decimal literal when given an 
   explicitly positive string representation`, () => {
-    expect(getNumber('+0,0', 'fr-BE')).toBeCloseTo(0.0, 20);
-    expect(getNumber('+0,45', 'fr-BE')).toBeCloseTo(0.45, 20);
-    expect(getNumber('+0,3', 'fr-BE')).toBeCloseTo(0.3, 20);
-    expect(getNumber('+0,243225', 'fr-BE')).toBeCloseTo(0.243225, 20);
-    expect(getNumber('+200', 'fr-BE')).toBeCloseTo(200, 20);
-    expect(getNumber('+200,45', 'fr-BE')).toBeCloseTo(200.45, 20);
-    expect(getNumber('+873,00', 'fr-BE')).toBeCloseTo(873.0, 20);
-    expect(getNumber('+2 050', 'fr-BE')).toBeCloseTo(2050, 20);
-    expect(getNumber('+2 000,30', 'fr-BE')).toBeCloseTo(2000.3, 20);
-    expect(getNumber('+2 342,0', 'fr-BE')).toBeCloseTo(2342.0, 20);
-    expect(getNumber('+20 000', 'fr-BE')).toBeCloseTo(20000, 20);
-    expect(getNumber('+20 000,34', 'fr-BE')).toBeCloseTo(20000.34, 20);
-    expect(getNumber('+200 000', 'fr-BE')).toBeCloseTo(200000, 20);
-    expect(getNumber('+2 000 000', 'fr-BE')).toBeCloseTo(2000000, 20);
-    expect(getNumber('+12 054 100,55', 'fr-BE')).toBeCloseTo(12054100.55, 20);
+    expect(getNumber('+0,0', 'fr-BE')).toBeCloseTo(0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+0,45', 'fr-BE')).toBeCloseTo(0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('+0,3', 'fr-BE')).toBeCloseTo(0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('+0,243225', 'fr-BE')).toBeCloseTo(0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('+200', 'fr-BE')).toBeCloseTo(200, supportedNumberOfFractionDigits);
+    expect(getNumber('+200,45', 'fr-BE')).toBeCloseTo(200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('+873,00', 'fr-BE')).toBeCloseTo(873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+2 050', 'fr-BE')).toBeCloseTo(2050, supportedNumberOfFractionDigits);
+    expect(getNumber('+2 000,30', 'fr-BE')).toBeCloseTo(2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('+2 342,0', 'fr-BE')).toBeCloseTo(2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+20 000', 'fr-BE')).toBeCloseTo(20000, supportedNumberOfFractionDigits);
+    expect(getNumber('+20 000,34', 'fr-BE')).toBeCloseTo(20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('+200 000', 'fr-BE')).toBeCloseTo(200000, supportedNumberOfFractionDigits);
+    expect(getNumber('+2 000 000', 'fr-BE')).toBeCloseTo(2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('+12 054 100,55', 'fr-BE')).toBeCloseTo(12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Automatically)(Range: [0, 1]) It should return a possible decimal literal when given an
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr-BE', 0, 0, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-BE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-BE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -58,7 +61,10 @@ describe('Testing `getNumber` with `fr-BE` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr-BE', 1, 100, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-BE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-BE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -66,7 +72,10 @@ describe('Testing `getNumber` with `fr-BE` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr-BE', 100, 1000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-BE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-BE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -74,7 +83,10 @@ describe('Testing `getNumber` with `fr-BE` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr-BE', 1000, 10000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-BE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-BE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -82,7 +94,10 @@ describe('Testing `getNumber` with `fr-BE` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr-BE', 10000, 100000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-BE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-BE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -90,7 +105,10 @@ describe('Testing `getNumber` with `fr-BE` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr-BE', 100000, 1000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-BE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-BE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -98,7 +116,10 @@ describe('Testing `getNumber` with `fr-BE` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr-BE', 1000000, 10000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-BE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-BE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -106,7 +127,10 @@ describe('Testing `getNumber` with `fr-BE` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr-BE', 10000000, 100000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-BE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-BE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -114,7 +138,10 @@ describe('Testing `getNumber` with `fr-BE` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr-BE', 100000000, 1000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-BE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-BE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -122,7 +149,10 @@ describe('Testing `getNumber` with `fr-BE` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr-BE', 1000000000, 10000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-BE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-BE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -130,7 +160,10 @@ describe('Testing `getNumber` with `fr-BE` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr-BE', 10000000000, 100000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-BE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-BE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -138,7 +171,10 @@ describe('Testing `getNumber` with `fr-BE` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr-BE', 100000000000, 1000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-BE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-BE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -146,7 +182,10 @@ describe('Testing `getNumber` with `fr-BE` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr-BE', 1000000000000, 10000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-BE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-BE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -154,7 +193,10 @@ describe('Testing `getNumber` with `fr-BE` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr-BE', 10000000000000, 100000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-BE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-BE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 });
@@ -162,28 +204,31 @@ describe('Testing `getNumber` with `fr-BE` locale on positive numbers', () => {
 describe('Testing `getNumber` with `fr-BE` locale on negative numbers', () => {
   test(`(Manually) It should return a negative decimal literal when given a
   negative string representation`, () => {
-    expect(getNumber('-0,0', 'fr-BE')).toBeCloseTo(-0.0, 20);
-    expect(getNumber('-0,45', 'fr-BE')).toBeCloseTo(-0.45, 20);
-    expect(getNumber('-0,3', 'fr-BE')).toBeCloseTo(-0.3, 20);
-    expect(getNumber('-0,243225', 'fr-BE')).toBeCloseTo(-0.243225, 20);
-    expect(getNumber('-200', 'fr-BE')).toBeCloseTo(-200, 20);
-    expect(getNumber('-200,45', 'fr-BE')).toBeCloseTo(-200.45, 20);
-    expect(getNumber('-873,00', 'fr-BE')).toBeCloseTo(-873.0, 20);
-    expect(getNumber('-2 050', 'fr-BE')).toBeCloseTo(-2050, 20);
-    expect(getNumber('-2 000,30', 'fr-BE')).toBeCloseTo(-2000.3, 20);
-    expect(getNumber('-2 342,0', 'fr-BE')).toBeCloseTo(-2342.0, 20);
-    expect(getNumber('-20 000', 'fr-BE')).toBeCloseTo(-20000, 20);
-    expect(getNumber('-20 000,34', 'fr-BE')).toBeCloseTo(-20000.34, 20);
-    expect(getNumber('-200 000', 'fr-BE')).toBeCloseTo(-200000, 20);
-    expect(getNumber('-2 000 000', 'fr-BE')).toBeCloseTo(-2000000, 20);
-    expect(getNumber('-12 054 100,55', 'fr-BE')).toBeCloseTo(-12054100.55, 20);
+    expect(getNumber('-0,0', 'fr-BE')).toBeCloseTo(-0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-0,45', 'fr-BE')).toBeCloseTo(-0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('-0,3', 'fr-BE')).toBeCloseTo(-0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('-0,243225', 'fr-BE')).toBeCloseTo(-0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('-200', 'fr-BE')).toBeCloseTo(-200, supportedNumberOfFractionDigits);
+    expect(getNumber('-200,45', 'fr-BE')).toBeCloseTo(-200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('-873,00', 'fr-BE')).toBeCloseTo(-873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-2 050', 'fr-BE')).toBeCloseTo(-2050, supportedNumberOfFractionDigits);
+    expect(getNumber('-2 000,30', 'fr-BE')).toBeCloseTo(-2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('-2 342,0', 'fr-BE')).toBeCloseTo(-2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-20 000', 'fr-BE')).toBeCloseTo(-20000, supportedNumberOfFractionDigits);
+    expect(getNumber('-20 000,34', 'fr-BE')).toBeCloseTo(-20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('-200 000', 'fr-BE')).toBeCloseTo(-200000, supportedNumberOfFractionDigits);
+    expect(getNumber('-2 000 000', 'fr-BE')).toBeCloseTo(-2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('-12 054 100,55', 'fr-BE')).toBeCloseTo(-12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Automatically)(Range: [-1, 0]) It should return a possible decimal literal when given an
   negative string representation`, () => {
     const testCases = testCaseGenerator('fr-BE', 0, -2, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-BE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-BE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -191,7 +236,10 @@ describe('Testing `getNumber` with `fr-BE` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('fr-BE', -100, -1, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-BE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-BE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -199,7 +247,10 @@ describe('Testing `getNumber` with `fr-BE` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('fr-BE', -1000, -100, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-BE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-BE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -207,7 +258,10 @@ describe('Testing `getNumber` with `fr-BE` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('fr-BE', -10000, -1000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-BE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-BE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -215,7 +269,10 @@ describe('Testing `getNumber` with `fr-BE` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('fr-BE', -100000, -10000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-BE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-BE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -223,7 +280,10 @@ describe('Testing `getNumber` with `fr-BE` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('fr-BE', -1000000, -100000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-BE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-BE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -231,7 +291,10 @@ describe('Testing `getNumber` with `fr-BE` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('fr-BE', -10000000, -1000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-BE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-BE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -239,7 +302,10 @@ describe('Testing `getNumber` with `fr-BE` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('fr-BE', -100000000, -10000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-BE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-BE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -247,7 +313,10 @@ describe('Testing `getNumber` with `fr-BE` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('fr-BE', -1000000000, -100000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-BE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-BE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -255,7 +324,10 @@ describe('Testing `getNumber` with `fr-BE` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('fr-BE', -10000000000, -1000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-BE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-BE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -263,7 +335,10 @@ describe('Testing `getNumber` with `fr-BE` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('fr-BE', -100000000000, -10000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-BE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-BE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -271,7 +346,10 @@ describe('Testing `getNumber` with `fr-BE` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('fr-BE', -1000000000000, -100000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-BE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-BE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -279,7 +357,10 @@ describe('Testing `getNumber` with `fr-BE` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('fr-BE', -10000000000000, -1000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-BE')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-BE')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 });

--- a/src/get-number/specs/get-number.fr-ca.spec.js
+++ b/src/get-number/specs/get-number.fr-ca.spec.js
@@ -1,5 +1,5 @@
 const getNumber = require('../get-number');
-const testCaseGenerator = require('./test-case-generator');
+const { testCaseGenerator, supportedNumberOfFractionDigits } = require('./test-case-generator');
 
 beforeEach(() => {
   // Making sure the `console.error` implementation is empty
@@ -10,47 +10,50 @@ beforeEach(() => {
 describe('Testing `getNumber` with `fr-CA` locale on positive numbers', () => {
   test(`(Manually) It should return a positive decimal literal when given an 
   implicitly positive string representation`, () => {
-    expect(getNumber('0,0', 'fr-CA')).toBeCloseTo(0.0, 20);
-    expect(getNumber('0,45', 'fr-CA')).toBeCloseTo(0.45, 20);
-    expect(getNumber('0,3', 'fr-CA')).toBeCloseTo(0.3, 20);
-    expect(getNumber('0,243225', 'fr-CA')).toBeCloseTo(0.243225, 20);
-    expect(getNumber('200', 'fr-CA')).toBeCloseTo(200, 20);
-    expect(getNumber('200,45', 'fr-CA')).toBeCloseTo(200.45, 20);
-    expect(getNumber('873,00', 'fr-CA')).toBeCloseTo(873.0, 20);
-    expect(getNumber('2 050', 'fr-CA')).toBeCloseTo(2050, 20);
-    expect(getNumber('2 000,30', 'fr-CA')).toBeCloseTo(2000.3, 20);
-    expect(getNumber('2 342,0', 'fr-CA')).toBeCloseTo(2342.0, 20);
-    expect(getNumber('20 000', 'fr-CA')).toBeCloseTo(20000, 20);
-    expect(getNumber('20 000,34', 'fr-CA')).toBeCloseTo(20000.34, 20);
-    expect(getNumber('200 000', 'fr-CA')).toBeCloseTo(200000, 20);
-    expect(getNumber('2 000 000', 'fr-CA')).toBeCloseTo(2000000, 20);
-    expect(getNumber('12 054 100,55', 'fr-CA')).toBeCloseTo(12054100.55, 20);
+    expect(getNumber('0,0', 'fr-CA')).toBeCloseTo(0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('0,45', 'fr-CA')).toBeCloseTo(0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('0,3', 'fr-CA')).toBeCloseTo(0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('0,243225', 'fr-CA')).toBeCloseTo(0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('200', 'fr-CA')).toBeCloseTo(200, supportedNumberOfFractionDigits);
+    expect(getNumber('200,45', 'fr-CA')).toBeCloseTo(200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('873,00', 'fr-CA')).toBeCloseTo(873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('2 050', 'fr-CA')).toBeCloseTo(2050, supportedNumberOfFractionDigits);
+    expect(getNumber('2 000,30', 'fr-CA')).toBeCloseTo(2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('2 342,0', 'fr-CA')).toBeCloseTo(2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('20 000', 'fr-CA')).toBeCloseTo(20000, supportedNumberOfFractionDigits);
+    expect(getNumber('20 000,34', 'fr-CA')).toBeCloseTo(20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('200 000', 'fr-CA')).toBeCloseTo(200000, supportedNumberOfFractionDigits);
+    expect(getNumber('2 000 000', 'fr-CA')).toBeCloseTo(2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('12 054 100,55', 'fr-CA')).toBeCloseTo(12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Manually) It should return a positive decimal literal when given an 
   explicitly positive string representation`, () => {
-    expect(getNumber('+0,0', 'fr-CA')).toBeCloseTo(0.0, 20);
-    expect(getNumber('+0,45', 'fr-CA')).toBeCloseTo(0.45, 20);
-    expect(getNumber('+0,3', 'fr-CA')).toBeCloseTo(0.3, 20);
-    expect(getNumber('+0,243225', 'fr-CA')).toBeCloseTo(0.243225, 20);
-    expect(getNumber('+200', 'fr-CA')).toBeCloseTo(200, 20);
-    expect(getNumber('+200,45', 'fr-CA')).toBeCloseTo(200.45, 20);
-    expect(getNumber('+873,00', 'fr-CA')).toBeCloseTo(873.0, 20);
-    expect(getNumber('+2 050', 'fr-CA')).toBeCloseTo(2050, 20);
-    expect(getNumber('+2 000,30', 'fr-CA')).toBeCloseTo(2000.3, 20);
-    expect(getNumber('+2 342,0', 'fr-CA')).toBeCloseTo(2342.0, 20);
-    expect(getNumber('+20 000', 'fr-CA')).toBeCloseTo(20000, 20);
-    expect(getNumber('+20 000,34', 'fr-CA')).toBeCloseTo(20000.34, 20);
-    expect(getNumber('+200 000', 'fr-CA')).toBeCloseTo(200000, 20);
-    expect(getNumber('+2 000 000', 'fr-CA')).toBeCloseTo(2000000, 20);
-    expect(getNumber('+12 054 100,55', 'fr-CA')).toBeCloseTo(12054100.55, 20);
+    expect(getNumber('+0,0', 'fr-CA')).toBeCloseTo(0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+0,45', 'fr-CA')).toBeCloseTo(0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('+0,3', 'fr-CA')).toBeCloseTo(0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('+0,243225', 'fr-CA')).toBeCloseTo(0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('+200', 'fr-CA')).toBeCloseTo(200, supportedNumberOfFractionDigits);
+    expect(getNumber('+200,45', 'fr-CA')).toBeCloseTo(200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('+873,00', 'fr-CA')).toBeCloseTo(873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+2 050', 'fr-CA')).toBeCloseTo(2050, supportedNumberOfFractionDigits);
+    expect(getNumber('+2 000,30', 'fr-CA')).toBeCloseTo(2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('+2 342,0', 'fr-CA')).toBeCloseTo(2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+20 000', 'fr-CA')).toBeCloseTo(20000, supportedNumberOfFractionDigits);
+    expect(getNumber('+20 000,34', 'fr-CA')).toBeCloseTo(20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('+200 000', 'fr-CA')).toBeCloseTo(200000, supportedNumberOfFractionDigits);
+    expect(getNumber('+2 000 000', 'fr-CA')).toBeCloseTo(2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('+12 054 100,55', 'fr-CA')).toBeCloseTo(12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Automatically)(Range: [0, 1]) It should return a possible decimal literal when given an
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr-CA', 0, 0, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-CA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-CA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -58,7 +61,10 @@ describe('Testing `getNumber` with `fr-CA` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr-CA', 1, 100, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-CA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-CA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -66,7 +72,10 @@ describe('Testing `getNumber` with `fr-CA` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr-CA', 100, 1000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-CA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-CA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -74,7 +83,10 @@ describe('Testing `getNumber` with `fr-CA` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr-CA', 1000, 10000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-CA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-CA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -82,7 +94,10 @@ describe('Testing `getNumber` with `fr-CA` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr-CA', 10000, 100000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-CA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-CA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -90,7 +105,10 @@ describe('Testing `getNumber` with `fr-CA` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr-CA', 100000, 1000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-CA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-CA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -98,7 +116,10 @@ describe('Testing `getNumber` with `fr-CA` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr-CA', 1000000, 10000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-CA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-CA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -106,7 +127,10 @@ describe('Testing `getNumber` with `fr-CA` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr-CA', 10000000, 100000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-CA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-CA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -114,7 +138,10 @@ describe('Testing `getNumber` with `fr-CA` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr-CA', 100000000, 1000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-CA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-CA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -122,7 +149,10 @@ describe('Testing `getNumber` with `fr-CA` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr-CA', 1000000000, 10000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-CA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-CA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -130,7 +160,10 @@ describe('Testing `getNumber` with `fr-CA` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr-CA', 10000000000, 100000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-CA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-CA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -138,7 +171,10 @@ describe('Testing `getNumber` with `fr-CA` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr-CA', 100000000000, 1000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-CA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-CA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -146,7 +182,10 @@ describe('Testing `getNumber` with `fr-CA` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr-CA', 1000000000000, 10000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-CA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-CA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -154,7 +193,10 @@ describe('Testing `getNumber` with `fr-CA` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr-CA', 10000000000000, 100000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-CA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-CA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 });
@@ -162,28 +204,31 @@ describe('Testing `getNumber` with `fr-CA` locale on positive numbers', () => {
 describe('Testing `getNumber` with `fr-CA` locale on negative numbers', () => {
   test(`(Manually) It should return a negative decimal literal when given a
   negative string representation`, () => {
-    expect(getNumber('-0,0', 'fr-CA')).toBeCloseTo(-0.0, 20);
-    expect(getNumber('-0,45', 'fr-CA')).toBeCloseTo(-0.45, 20);
-    expect(getNumber('-0,3', 'fr-CA')).toBeCloseTo(-0.3, 20);
-    expect(getNumber('-0,243225', 'fr-CA')).toBeCloseTo(-0.243225, 20);
-    expect(getNumber('-200', 'fr-CA')).toBeCloseTo(-200, 20);
-    expect(getNumber('-200,45', 'fr-CA')).toBeCloseTo(-200.45, 20);
-    expect(getNumber('-873,00', 'fr-CA')).toBeCloseTo(-873.0, 20);
-    expect(getNumber('-2 050', 'fr-CA')).toBeCloseTo(-2050, 20);
-    expect(getNumber('-2 000,30', 'fr-CA')).toBeCloseTo(-2000.3, 20);
-    expect(getNumber('-2 342,0', 'fr-CA')).toBeCloseTo(-2342.0, 20);
-    expect(getNumber('-20 000', 'fr-CA')).toBeCloseTo(-20000, 20);
-    expect(getNumber('-20 000,34', 'fr-CA')).toBeCloseTo(-20000.34, 20);
-    expect(getNumber('-200 000', 'fr-CA')).toBeCloseTo(-200000, 20);
-    expect(getNumber('-2 000 000', 'fr-CA')).toBeCloseTo(-2000000, 20);
-    expect(getNumber('-12 054 100,55', 'fr-CA')).toBeCloseTo(-12054100.55, 20);
+    expect(getNumber('-0,0', 'fr-CA')).toBeCloseTo(-0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-0,45', 'fr-CA')).toBeCloseTo(-0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('-0,3', 'fr-CA')).toBeCloseTo(-0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('-0,243225', 'fr-CA')).toBeCloseTo(-0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('-200', 'fr-CA')).toBeCloseTo(-200, supportedNumberOfFractionDigits);
+    expect(getNumber('-200,45', 'fr-CA')).toBeCloseTo(-200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('-873,00', 'fr-CA')).toBeCloseTo(-873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-2 050', 'fr-CA')).toBeCloseTo(-2050, supportedNumberOfFractionDigits);
+    expect(getNumber('-2 000,30', 'fr-CA')).toBeCloseTo(-2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('-2 342,0', 'fr-CA')).toBeCloseTo(-2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-20 000', 'fr-CA')).toBeCloseTo(-20000, supportedNumberOfFractionDigits);
+    expect(getNumber('-20 000,34', 'fr-CA')).toBeCloseTo(-20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('-200 000', 'fr-CA')).toBeCloseTo(-200000, supportedNumberOfFractionDigits);
+    expect(getNumber('-2 000 000', 'fr-CA')).toBeCloseTo(-2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('-12 054 100,55', 'fr-CA')).toBeCloseTo(-12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Automatically)(Range: [-1, 0]) It should return a possible decimal literal when given an
   negative string representation`, () => {
     const testCases = testCaseGenerator('fr-CA', 0, -2, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-CA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-CA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -191,7 +236,10 @@ describe('Testing `getNumber` with `fr-CA` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('fr-CA', -100, -1, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-CA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-CA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -199,7 +247,10 @@ describe('Testing `getNumber` with `fr-CA` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('fr-CA', -1000, -100, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-CA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-CA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -207,7 +258,10 @@ describe('Testing `getNumber` with `fr-CA` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('fr-CA', -10000, -1000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-CA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-CA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -215,7 +269,10 @@ describe('Testing `getNumber` with `fr-CA` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('fr-CA', -100000, -10000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-CA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-CA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -223,7 +280,10 @@ describe('Testing `getNumber` with `fr-CA` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('fr-CA', -1000000, -100000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-CA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-CA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -231,7 +291,10 @@ describe('Testing `getNumber` with `fr-CA` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('fr-CA', -10000000, -1000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-CA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-CA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -239,7 +302,10 @@ describe('Testing `getNumber` with `fr-CA` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('fr-CA', -100000000, -10000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-CA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-CA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -247,7 +313,10 @@ describe('Testing `getNumber` with `fr-CA` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('fr-CA', -1000000000, -100000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-CA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-CA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -255,7 +324,10 @@ describe('Testing `getNumber` with `fr-CA` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('fr-CA', -10000000000, -1000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-CA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-CA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -263,7 +335,10 @@ describe('Testing `getNumber` with `fr-CA` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('fr-CA', -100000000000, -10000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-CA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-CA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -271,7 +346,10 @@ describe('Testing `getNumber` with `fr-CA` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('fr-CA', -1000000000000, -100000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-CA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-CA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -279,7 +357,10 @@ describe('Testing `getNumber` with `fr-CA` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('fr-CA', -10000000000000, -1000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-CA')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-CA')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 });

--- a/src/get-number/specs/get-number.fr-ch.spec.js
+++ b/src/get-number/specs/get-number.fr-ch.spec.js
@@ -1,5 +1,5 @@
 const getNumber = require('../get-number');
-const testCaseGenerator = require('./test-case-generator');
+const { testCaseGenerator, supportedNumberOfFractionDigits } = require('./test-case-generator');
 
 beforeEach(() => {
   // Making sure the `console.error` implementation is empty
@@ -10,47 +10,50 @@ beforeEach(() => {
 describe('Testing `getNumber` with `fr-CH` locale on positive numbers', () => {
   test(`(Manually) It should return a positive decimal literal when given an 
   implicitly positive string representation`, () => {
-    expect(getNumber('0,0', 'fr-CH')).toBeCloseTo(0.0, 20);
-    expect(getNumber('0,45', 'fr-CH')).toBeCloseTo(0.45, 20);
-    expect(getNumber('0,3', 'fr-CH')).toBeCloseTo(0.3, 20);
-    expect(getNumber('0,243225', 'fr-CH')).toBeCloseTo(0.243225, 20);
-    expect(getNumber('200', 'fr-CH')).toBeCloseTo(200, 20);
-    expect(getNumber('200,45', 'fr-CH')).toBeCloseTo(200.45, 20);
-    expect(getNumber('873,00', 'fr-CH')).toBeCloseTo(873.0, 20);
-    expect(getNumber('2 050', 'fr-CH')).toBeCloseTo(2050, 20);
-    expect(getNumber('2 000,30', 'fr-CH')).toBeCloseTo(2000.3, 20);
-    expect(getNumber('2 342,0', 'fr-CH')).toBeCloseTo(2342.0, 20);
-    expect(getNumber('20 000', 'fr-CH')).toBeCloseTo(20000, 20);
-    expect(getNumber('20 000,34', 'fr-CH')).toBeCloseTo(20000.34, 20);
-    expect(getNumber('200 000', 'fr-CH')).toBeCloseTo(200000, 20);
-    expect(getNumber('2 000 000', 'fr-CH')).toBeCloseTo(2000000, 20);
-    expect(getNumber('12 054 100,55', 'fr-CH')).toBeCloseTo(12054100.55, 20);
+    expect(getNumber('0,0', 'fr-CH')).toBeCloseTo(0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('0,45', 'fr-CH')).toBeCloseTo(0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('0,3', 'fr-CH')).toBeCloseTo(0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('0,243225', 'fr-CH')).toBeCloseTo(0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('200', 'fr-CH')).toBeCloseTo(200, supportedNumberOfFractionDigits);
+    expect(getNumber('200,45', 'fr-CH')).toBeCloseTo(200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('873,00', 'fr-CH')).toBeCloseTo(873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('2 050', 'fr-CH')).toBeCloseTo(2050, supportedNumberOfFractionDigits);
+    expect(getNumber('2 000,30', 'fr-CH')).toBeCloseTo(2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('2 342,0', 'fr-CH')).toBeCloseTo(2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('20 000', 'fr-CH')).toBeCloseTo(20000, supportedNumberOfFractionDigits);
+    expect(getNumber('20 000,34', 'fr-CH')).toBeCloseTo(20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('200 000', 'fr-CH')).toBeCloseTo(200000, supportedNumberOfFractionDigits);
+    expect(getNumber('2 000 000', 'fr-CH')).toBeCloseTo(2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('12 054 100,55', 'fr-CH')).toBeCloseTo(12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Manually) It should return a positive decimal literal when given an 
   explicitly positive string representation`, () => {
-    expect(getNumber('+0,0', 'fr-CH')).toBeCloseTo(0.0, 20);
-    expect(getNumber('+0,45', 'fr-CH')).toBeCloseTo(0.45, 20);
-    expect(getNumber('+0,3', 'fr-CH')).toBeCloseTo(0.3, 20);
-    expect(getNumber('+0,243225', 'fr-CH')).toBeCloseTo(0.243225, 20);
-    expect(getNumber('+200', 'fr-CH')).toBeCloseTo(200, 20);
-    expect(getNumber('+200,45', 'fr-CH')).toBeCloseTo(200.45, 20);
-    expect(getNumber('+873,00', 'fr-CH')).toBeCloseTo(873.0, 20);
-    expect(getNumber('+2 050', 'fr-CH')).toBeCloseTo(2050, 20);
-    expect(getNumber('+2 000,30', 'fr-CH')).toBeCloseTo(2000.3, 20);
-    expect(getNumber('+2 342,0', 'fr-CH')).toBeCloseTo(2342.0, 20);
-    expect(getNumber('+20 000', 'fr-CH')).toBeCloseTo(20000, 20);
-    expect(getNumber('+20 000,34', 'fr-CH')).toBeCloseTo(20000.34, 20);
-    expect(getNumber('+200 000', 'fr-CH')).toBeCloseTo(200000, 20);
-    expect(getNumber('+2 000 000', 'fr-CH')).toBeCloseTo(2000000, 20);
-    expect(getNumber('+12 054 100,55', 'fr-CH')).toBeCloseTo(12054100.55, 20);
+    expect(getNumber('+0,0', 'fr-CH')).toBeCloseTo(0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+0,45', 'fr-CH')).toBeCloseTo(0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('+0,3', 'fr-CH')).toBeCloseTo(0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('+0,243225', 'fr-CH')).toBeCloseTo(0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('+200', 'fr-CH')).toBeCloseTo(200, supportedNumberOfFractionDigits);
+    expect(getNumber('+200,45', 'fr-CH')).toBeCloseTo(200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('+873,00', 'fr-CH')).toBeCloseTo(873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+2 050', 'fr-CH')).toBeCloseTo(2050, supportedNumberOfFractionDigits);
+    expect(getNumber('+2 000,30', 'fr-CH')).toBeCloseTo(2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('+2 342,0', 'fr-CH')).toBeCloseTo(2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+20 000', 'fr-CH')).toBeCloseTo(20000, supportedNumberOfFractionDigits);
+    expect(getNumber('+20 000,34', 'fr-CH')).toBeCloseTo(20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('+200 000', 'fr-CH')).toBeCloseTo(200000, supportedNumberOfFractionDigits);
+    expect(getNumber('+2 000 000', 'fr-CH')).toBeCloseTo(2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('+12 054 100,55', 'fr-CH')).toBeCloseTo(12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Automatically)(Range: [0, 1]) It should return a possible decimal literal when given an
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr-CH', 0, 0, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-CH')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-CH')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -58,7 +61,10 @@ describe('Testing `getNumber` with `fr-CH` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr-CH', 1, 100, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-CH')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-CH')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -66,7 +72,10 @@ describe('Testing `getNumber` with `fr-CH` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr-CH', 100, 1000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-CH')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-CH')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -74,7 +83,10 @@ describe('Testing `getNumber` with `fr-CH` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr-CH', 1000, 10000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-CH')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-CH')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -82,7 +94,10 @@ describe('Testing `getNumber` with `fr-CH` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr-CH', 10000, 100000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-CH')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-CH')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -90,7 +105,10 @@ describe('Testing `getNumber` with `fr-CH` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr-CH', 100000, 1000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-CH')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-CH')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -98,7 +116,10 @@ describe('Testing `getNumber` with `fr-CH` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr-CH', 1000000, 10000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-CH')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-CH')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -106,7 +127,10 @@ describe('Testing `getNumber` with `fr-CH` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr-CH', 10000000, 100000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-CH')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-CH')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -114,7 +138,10 @@ describe('Testing `getNumber` with `fr-CH` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr-CH', 100000000, 1000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-CH')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-CH')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -122,7 +149,10 @@ describe('Testing `getNumber` with `fr-CH` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr-CH', 1000000000, 10000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-CH')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-CH')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -130,7 +160,10 @@ describe('Testing `getNumber` with `fr-CH` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr-CH', 10000000000, 100000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-CH')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-CH')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -138,7 +171,10 @@ describe('Testing `getNumber` with `fr-CH` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr-CH', 100000000000, 1000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-CH')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-CH')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -146,7 +182,10 @@ describe('Testing `getNumber` with `fr-CH` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr-CH', 1000000000000, 10000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-CH')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-CH')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -154,7 +193,10 @@ describe('Testing `getNumber` with `fr-CH` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr-CH', 10000000000000, 100000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-CH')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-CH')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 });
@@ -162,28 +204,31 @@ describe('Testing `getNumber` with `fr-CH` locale on positive numbers', () => {
 describe('Testing `getNumber` with `fr-CH` locale on negative numbers', () => {
   test(`(Manually) It should return a negative decimal literal when given a
   negative string representation`, () => {
-    expect(getNumber('-0,0', 'fr-CH')).toBeCloseTo(-0.0, 20);
-    expect(getNumber('-0,45', 'fr-CH')).toBeCloseTo(-0.45, 20);
-    expect(getNumber('-0,3', 'fr-CH')).toBeCloseTo(-0.3, 20);
-    expect(getNumber('-0,243225', 'fr-CH')).toBeCloseTo(-0.243225, 20);
-    expect(getNumber('-200', 'fr-CH')).toBeCloseTo(-200, 20);
-    expect(getNumber('-200,45', 'fr-CH')).toBeCloseTo(-200.45, 20);
-    expect(getNumber('-873,00', 'fr-CH')).toBeCloseTo(-873.0, 20);
-    expect(getNumber('-2 050', 'fr-CH')).toBeCloseTo(-2050, 20);
-    expect(getNumber('-2 000,30', 'fr-CH')).toBeCloseTo(-2000.3, 20);
-    expect(getNumber('-2 342,0', 'fr-CH')).toBeCloseTo(-2342.0, 20);
-    expect(getNumber('-20 000', 'fr-CH')).toBeCloseTo(-20000, 20);
-    expect(getNumber('-20 000,34', 'fr-CH')).toBeCloseTo(-20000.34, 20);
-    expect(getNumber('-200 000', 'fr-CH')).toBeCloseTo(-200000, 20);
-    expect(getNumber('-2 000 000', 'fr-CH')).toBeCloseTo(-2000000, 20);
-    expect(getNumber('-12 054 100,55', 'fr-CH')).toBeCloseTo(-12054100.55, 20);
+    expect(getNumber('-0,0', 'fr-CH')).toBeCloseTo(-0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-0,45', 'fr-CH')).toBeCloseTo(-0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('-0,3', 'fr-CH')).toBeCloseTo(-0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('-0,243225', 'fr-CH')).toBeCloseTo(-0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('-200', 'fr-CH')).toBeCloseTo(-200, supportedNumberOfFractionDigits);
+    expect(getNumber('-200,45', 'fr-CH')).toBeCloseTo(-200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('-873,00', 'fr-CH')).toBeCloseTo(-873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-2 050', 'fr-CH')).toBeCloseTo(-2050, supportedNumberOfFractionDigits);
+    expect(getNumber('-2 000,30', 'fr-CH')).toBeCloseTo(-2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('-2 342,0', 'fr-CH')).toBeCloseTo(-2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-20 000', 'fr-CH')).toBeCloseTo(-20000, supportedNumberOfFractionDigits);
+    expect(getNumber('-20 000,34', 'fr-CH')).toBeCloseTo(-20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('-200 000', 'fr-CH')).toBeCloseTo(-200000, supportedNumberOfFractionDigits);
+    expect(getNumber('-2 000 000', 'fr-CH')).toBeCloseTo(-2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('-12 054 100,55', 'fr-CH')).toBeCloseTo(-12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Automatically)(Range: [-1, 0]) It should return a possible decimal literal when given an
   negative string representation`, () => {
     const testCases = testCaseGenerator('fr-CH', 0, -2, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-CH')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-CH')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -191,7 +236,10 @@ describe('Testing `getNumber` with `fr-CH` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('fr-CH', -100, -1, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-CH')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-CH')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -199,7 +247,10 @@ describe('Testing `getNumber` with `fr-CH` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('fr-CH', -1000, -100, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-CH')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-CH')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -207,7 +258,10 @@ describe('Testing `getNumber` with `fr-CH` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('fr-CH', -10000, -1000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-CH')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-CH')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -215,7 +269,10 @@ describe('Testing `getNumber` with `fr-CH` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('fr-CH', -100000, -10000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-CH')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-CH')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -223,7 +280,10 @@ describe('Testing `getNumber` with `fr-CH` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('fr-CH', -1000000, -100000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-CH')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-CH')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -231,7 +291,10 @@ describe('Testing `getNumber` with `fr-CH` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('fr-CH', -10000000, -1000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-CH')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-CH')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -239,7 +302,10 @@ describe('Testing `getNumber` with `fr-CH` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('fr-CH', -100000000, -10000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-CH')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-CH')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -247,7 +313,10 @@ describe('Testing `getNumber` with `fr-CH` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('fr-CH', -1000000000, -100000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-CH')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-CH')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -255,7 +324,10 @@ describe('Testing `getNumber` with `fr-CH` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('fr-CH', -10000000000, -1000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-CH')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-CH')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -263,7 +335,10 @@ describe('Testing `getNumber` with `fr-CH` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('fr-CH', -100000000000, -10000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-CH')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-CH')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -271,7 +346,10 @@ describe('Testing `getNumber` with `fr-CH` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('fr-CH', -1000000000000, -100000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-CH')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-CH')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -279,7 +357,10 @@ describe('Testing `getNumber` with `fr-CH` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('fr-CH', -10000000000000, -1000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-CH')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-CH')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 });

--- a/src/get-number/specs/get-number.fr-fr.spec.js
+++ b/src/get-number/specs/get-number.fr-fr.spec.js
@@ -1,5 +1,5 @@
 const getNumber = require('../get-number');
-const testCaseGenerator = require('./test-case-generator');
+const { testCaseGenerator, supportedNumberOfFractionDigits } = require('./test-case-generator');
 
 beforeEach(() => {
   // Making sure the `console.error` implementation is empty
@@ -10,47 +10,50 @@ beforeEach(() => {
 describe('Testing `getNumber` with `fr-FR` locale on positive numbers', () => {
   test(`(Manually) It should return a positive decimal literal when given an 
   implicitly positive string representation`, () => {
-    expect(getNumber('0,0', 'fr-FR')).toBeCloseTo(0.0, 20);
-    expect(getNumber('0,45', 'fr-FR')).toBeCloseTo(0.45, 20);
-    expect(getNumber('0,3', 'fr-FR')).toBeCloseTo(0.3, 20);
-    expect(getNumber('0,243225', 'fr-FR')).toBeCloseTo(0.243225, 20);
-    expect(getNumber('200', 'fr-FR')).toBeCloseTo(200, 20);
-    expect(getNumber('200,45', 'fr-FR')).toBeCloseTo(200.45, 20);
-    expect(getNumber('873,00', 'fr-FR')).toBeCloseTo(873.0, 20);
-    expect(getNumber('2 050', 'fr-FR')).toBeCloseTo(2050, 20);
-    expect(getNumber('2 000,30', 'fr-FR')).toBeCloseTo(2000.3, 20);
-    expect(getNumber('2 342,0', 'fr-FR')).toBeCloseTo(2342.0, 20);
-    expect(getNumber('20 000', 'fr-FR')).toBeCloseTo(20000, 20);
-    expect(getNumber('20 000,34', 'fr-FR')).toBeCloseTo(20000.34, 20);
-    expect(getNumber('200 000', 'fr-FR')).toBeCloseTo(200000, 20);
-    expect(getNumber('2 000 000', 'fr-FR')).toBeCloseTo(2000000, 20);
-    expect(getNumber('12 054 100,55', 'fr-FR')).toBeCloseTo(12054100.55, 20);
+    expect(getNumber('0,0', 'fr-FR')).toBeCloseTo(0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('0,45', 'fr-FR')).toBeCloseTo(0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('0,3', 'fr-FR')).toBeCloseTo(0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('0,243225', 'fr-FR')).toBeCloseTo(0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('200', 'fr-FR')).toBeCloseTo(200, supportedNumberOfFractionDigits);
+    expect(getNumber('200,45', 'fr-FR')).toBeCloseTo(200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('873,00', 'fr-FR')).toBeCloseTo(873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('2 050', 'fr-FR')).toBeCloseTo(2050, supportedNumberOfFractionDigits);
+    expect(getNumber('2 000,30', 'fr-FR')).toBeCloseTo(2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('2 342,0', 'fr-FR')).toBeCloseTo(2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('20 000', 'fr-FR')).toBeCloseTo(20000, supportedNumberOfFractionDigits);
+    expect(getNumber('20 000,34', 'fr-FR')).toBeCloseTo(20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('200 000', 'fr-FR')).toBeCloseTo(200000, supportedNumberOfFractionDigits);
+    expect(getNumber('2 000 000', 'fr-FR')).toBeCloseTo(2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('12 054 100,55', 'fr-FR')).toBeCloseTo(12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Manually) It should return a positive decimal literal when given an 
   explicitly positive string representation`, () => {
-    expect(getNumber('+0,0', 'fr-FR')).toBeCloseTo(0.0, 20);
-    expect(getNumber('+0,45', 'fr-FR')).toBeCloseTo(0.45, 20);
-    expect(getNumber('+0,3', 'fr-FR')).toBeCloseTo(0.3, 20);
-    expect(getNumber('+0,243225', 'fr-FR')).toBeCloseTo(0.243225, 20);
-    expect(getNumber('+200', 'fr-FR')).toBeCloseTo(200, 20);
-    expect(getNumber('+200,45', 'fr-FR')).toBeCloseTo(200.45, 20);
-    expect(getNumber('+873,00', 'fr-FR')).toBeCloseTo(873.0, 20);
-    expect(getNumber('+2 050', 'fr-FR')).toBeCloseTo(2050, 20);
-    expect(getNumber('+2 000,30', 'fr-FR')).toBeCloseTo(2000.3, 20);
-    expect(getNumber('+2 342,0', 'fr-FR')).toBeCloseTo(2342.0, 20);
-    expect(getNumber('+20 000', 'fr-FR')).toBeCloseTo(20000, 20);
-    expect(getNumber('+20 000,34', 'fr-FR')).toBeCloseTo(20000.34, 20);
-    expect(getNumber('+200 000', 'fr-FR')).toBeCloseTo(200000, 20);
-    expect(getNumber('+2 000 000', 'fr-FR')).toBeCloseTo(2000000, 20);
-    expect(getNumber('+12 054 100,55', 'fr-FR')).toBeCloseTo(12054100.55, 20);
+    expect(getNumber('+0,0', 'fr-FR')).toBeCloseTo(0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+0,45', 'fr-FR')).toBeCloseTo(0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('+0,3', 'fr-FR')).toBeCloseTo(0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('+0,243225', 'fr-FR')).toBeCloseTo(0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('+200', 'fr-FR')).toBeCloseTo(200, supportedNumberOfFractionDigits);
+    expect(getNumber('+200,45', 'fr-FR')).toBeCloseTo(200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('+873,00', 'fr-FR')).toBeCloseTo(873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+2 050', 'fr-FR')).toBeCloseTo(2050, supportedNumberOfFractionDigits);
+    expect(getNumber('+2 000,30', 'fr-FR')).toBeCloseTo(2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('+2 342,0', 'fr-FR')).toBeCloseTo(2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+20 000', 'fr-FR')).toBeCloseTo(20000, supportedNumberOfFractionDigits);
+    expect(getNumber('+20 000,34', 'fr-FR')).toBeCloseTo(20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('+200 000', 'fr-FR')).toBeCloseTo(200000, supportedNumberOfFractionDigits);
+    expect(getNumber('+2 000 000', 'fr-FR')).toBeCloseTo(2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('+12 054 100,55', 'fr-FR')).toBeCloseTo(12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Automatically)(Range: [0, 1]) It should return a possible decimal literal when given an
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr-FR', 0, 0, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-FR')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-FR')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -58,7 +61,10 @@ describe('Testing `getNumber` with `fr-FR` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr-FR', 1, 100, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-FR')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-FR')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -66,7 +72,10 @@ describe('Testing `getNumber` with `fr-FR` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr-FR', 100, 1000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-FR')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-FR')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -74,7 +83,10 @@ describe('Testing `getNumber` with `fr-FR` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr-FR', 1000, 10000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-FR')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-FR')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -82,7 +94,10 @@ describe('Testing `getNumber` with `fr-FR` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr-FR', 10000, 100000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-FR')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-FR')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -90,7 +105,10 @@ describe('Testing `getNumber` with `fr-FR` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr-FR', 100000, 1000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-FR')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-FR')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -98,7 +116,10 @@ describe('Testing `getNumber` with `fr-FR` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr-FR', 1000000, 10000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-FR')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-FR')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -106,7 +127,10 @@ describe('Testing `getNumber` with `fr-FR` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr-FR', 10000000, 100000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-FR')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-FR')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -114,7 +138,10 @@ describe('Testing `getNumber` with `fr-FR` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr-FR', 100000000, 1000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-FR')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-FR')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -122,7 +149,10 @@ describe('Testing `getNumber` with `fr-FR` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr-FR', 1000000000, 10000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-FR')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-FR')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -130,7 +160,10 @@ describe('Testing `getNumber` with `fr-FR` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr-FR', 10000000000, 100000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-FR')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-FR')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -138,7 +171,10 @@ describe('Testing `getNumber` with `fr-FR` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr-FR', 100000000000, 1000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-FR')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-FR')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -146,7 +182,10 @@ describe('Testing `getNumber` with `fr-FR` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr-FR', 1000000000000, 10000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-FR')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-FR')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -154,7 +193,10 @@ describe('Testing `getNumber` with `fr-FR` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr-FR', 10000000000000, 100000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-FR')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-FR')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 });
@@ -162,28 +204,31 @@ describe('Testing `getNumber` with `fr-FR` locale on positive numbers', () => {
 describe('Testing `getNumber` with `fr-FR` locale on negative numbers', () => {
   test(`(Manually) It should return a negative decimal literal when given a
   negative string representation`, () => {
-    expect(getNumber('-0,0', 'fr-FR')).toBeCloseTo(-0.0, 20);
-    expect(getNumber('-0,45', 'fr-FR')).toBeCloseTo(-0.45, 20);
-    expect(getNumber('-0,3', 'fr-FR')).toBeCloseTo(-0.3, 20);
-    expect(getNumber('-0,243225', 'fr-FR')).toBeCloseTo(-0.243225, 20);
-    expect(getNumber('-200', 'fr-FR')).toBeCloseTo(-200, 20);
-    expect(getNumber('-200,45', 'fr-FR')).toBeCloseTo(-200.45, 20);
-    expect(getNumber('-873,00', 'fr-FR')).toBeCloseTo(-873.0, 20);
-    expect(getNumber('-2 050', 'fr-FR')).toBeCloseTo(-2050, 20);
-    expect(getNumber('-2 000,30', 'fr-FR')).toBeCloseTo(-2000.3, 20);
-    expect(getNumber('-2 342,0', 'fr-FR')).toBeCloseTo(-2342.0, 20);
-    expect(getNumber('-20 000', 'fr-FR')).toBeCloseTo(-20000, 20);
-    expect(getNumber('-20 000,34', 'fr-FR')).toBeCloseTo(-20000.34, 20);
-    expect(getNumber('-200 000', 'fr-FR')).toBeCloseTo(-200000, 20);
-    expect(getNumber('-2 000 000', 'fr-FR')).toBeCloseTo(-2000000, 20);
-    expect(getNumber('-12 054 100,55', 'fr-FR')).toBeCloseTo(-12054100.55, 20);
+    expect(getNumber('-0,0', 'fr-FR')).toBeCloseTo(-0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-0,45', 'fr-FR')).toBeCloseTo(-0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('-0,3', 'fr-FR')).toBeCloseTo(-0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('-0,243225', 'fr-FR')).toBeCloseTo(-0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('-200', 'fr-FR')).toBeCloseTo(-200, supportedNumberOfFractionDigits);
+    expect(getNumber('-200,45', 'fr-FR')).toBeCloseTo(-200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('-873,00', 'fr-FR')).toBeCloseTo(-873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-2 050', 'fr-FR')).toBeCloseTo(-2050, supportedNumberOfFractionDigits);
+    expect(getNumber('-2 000,30', 'fr-FR')).toBeCloseTo(-2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('-2 342,0', 'fr-FR')).toBeCloseTo(-2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-20 000', 'fr-FR')).toBeCloseTo(-20000, supportedNumberOfFractionDigits);
+    expect(getNumber('-20 000,34', 'fr-FR')).toBeCloseTo(-20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('-200 000', 'fr-FR')).toBeCloseTo(-200000, supportedNumberOfFractionDigits);
+    expect(getNumber('-2 000 000', 'fr-FR')).toBeCloseTo(-2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('-12 054 100,55', 'fr-FR')).toBeCloseTo(-12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Automatically)(Range: [-1, 0]) It should return a possible decimal literal when given an
   negative string representation`, () => {
     const testCases = testCaseGenerator('fr-FR', 0, -2, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-FR')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-FR')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -191,7 +236,10 @@ describe('Testing `getNumber` with `fr-FR` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('fr-FR', -100, -1, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-FR')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-FR')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -199,7 +247,10 @@ describe('Testing `getNumber` with `fr-FR` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('fr-FR', -1000, -100, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-FR')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-FR')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -207,7 +258,10 @@ describe('Testing `getNumber` with `fr-FR` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('fr-FR', -10000, -1000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-FR')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-FR')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -215,7 +269,10 @@ describe('Testing `getNumber` with `fr-FR` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('fr-FR', -100000, -10000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-FR')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-FR')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -223,7 +280,10 @@ describe('Testing `getNumber` with `fr-FR` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('fr-FR', -1000000, -100000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-FR')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-FR')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -231,7 +291,10 @@ describe('Testing `getNumber` with `fr-FR` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('fr-FR', -10000000, -1000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-FR')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-FR')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -239,7 +302,10 @@ describe('Testing `getNumber` with `fr-FR` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('fr-FR', -100000000, -10000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-FR')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-FR')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -247,7 +313,10 @@ describe('Testing `getNumber` with `fr-FR` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('fr-FR', -1000000000, -100000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-FR')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-FR')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -255,7 +324,10 @@ describe('Testing `getNumber` with `fr-FR` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('fr-FR', -10000000000, -1000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-FR')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-FR')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -263,7 +335,10 @@ describe('Testing `getNumber` with `fr-FR` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('fr-FR', -100000000000, -10000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-FR')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-FR')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -271,7 +346,10 @@ describe('Testing `getNumber` with `fr-FR` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('fr-FR', -1000000000000, -100000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-FR')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-FR')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -279,7 +357,10 @@ describe('Testing `getNumber` with `fr-FR` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('fr-FR', -10000000000000, -1000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr-FR')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr-FR')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 });

--- a/src/get-number/specs/get-number.fr.spec.js
+++ b/src/get-number/specs/get-number.fr.spec.js
@@ -1,5 +1,5 @@
 const getNumber = require('../get-number');
-const testCaseGenerator = require('./test-case-generator');
+const { testCaseGenerator, supportedNumberOfFractionDigits } = require('./test-case-generator');
 
 beforeEach(() => {
   // Making sure the `console.error` implementation is empty
@@ -10,47 +10,50 @@ beforeEach(() => {
 describe('Testing `getNumber` with `fr` locale on positive numbers', () => {
   test(`(Manually) It should return a positive decimal literal when given an 
   implicitly positive string representation`, () => {
-    expect(getNumber('0,0', 'fr')).toBeCloseTo(0.0, 20);
-    expect(getNumber('0,45', 'fr')).toBeCloseTo(0.45, 20);
-    expect(getNumber('0,3', 'fr')).toBeCloseTo(0.3, 20);
-    expect(getNumber('0,243225', 'fr')).toBeCloseTo(0.243225, 20);
-    expect(getNumber('200', 'fr')).toBeCloseTo(200, 20);
-    expect(getNumber('200,45', 'fr')).toBeCloseTo(200.45, 20);
-    expect(getNumber('873,00', 'fr')).toBeCloseTo(873.0, 20);
-    expect(getNumber('2 050', 'fr')).toBeCloseTo(2050, 20);
-    expect(getNumber('2 000,30', 'fr')).toBeCloseTo(2000.3, 20);
-    expect(getNumber('2 342,0', 'fr')).toBeCloseTo(2342.0, 20);
-    expect(getNumber('20 000', 'fr')).toBeCloseTo(20000, 20);
-    expect(getNumber('20 000,34', 'fr')).toBeCloseTo(20000.34, 20);
-    expect(getNumber('200 000', 'fr')).toBeCloseTo(200000, 20);
-    expect(getNumber('2 000 000', 'fr')).toBeCloseTo(2000000, 20);
-    expect(getNumber('12 054 100,55', 'fr')).toBeCloseTo(12054100.55, 20);
+    expect(getNumber('0,0', 'fr')).toBeCloseTo(0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('0,45', 'fr')).toBeCloseTo(0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('0,3', 'fr')).toBeCloseTo(0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('0,243225', 'fr')).toBeCloseTo(0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('200', 'fr')).toBeCloseTo(200, supportedNumberOfFractionDigits);
+    expect(getNumber('200,45', 'fr')).toBeCloseTo(200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('873,00', 'fr')).toBeCloseTo(873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('2 050', 'fr')).toBeCloseTo(2050, supportedNumberOfFractionDigits);
+    expect(getNumber('2 000,30', 'fr')).toBeCloseTo(2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('2 342,0', 'fr')).toBeCloseTo(2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('20 000', 'fr')).toBeCloseTo(20000, supportedNumberOfFractionDigits);
+    expect(getNumber('20 000,34', 'fr')).toBeCloseTo(20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('200 000', 'fr')).toBeCloseTo(200000, supportedNumberOfFractionDigits);
+    expect(getNumber('2 000 000', 'fr')).toBeCloseTo(2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('12 054 100,55', 'fr')).toBeCloseTo(12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Manually) It should return a positive decimal literal when given an 
   explicitly positive string representation`, () => {
-    expect(getNumber('+0,0', 'fr')).toBeCloseTo(0.0, 20);
-    expect(getNumber('+0,45', 'fr')).toBeCloseTo(0.45, 20);
-    expect(getNumber('+0,3', 'fr')).toBeCloseTo(0.3, 20);
-    expect(getNumber('+0,243225', 'fr')).toBeCloseTo(0.243225, 20);
-    expect(getNumber('+200', 'fr')).toBeCloseTo(200, 20);
-    expect(getNumber('+200,45', 'fr')).toBeCloseTo(200.45, 20);
-    expect(getNumber('+873,00', 'fr')).toBeCloseTo(873.0, 20);
-    expect(getNumber('+2 050', 'fr')).toBeCloseTo(2050, 20);
-    expect(getNumber('+2 000,30', 'fr')).toBeCloseTo(2000.3, 20);
-    expect(getNumber('+2 342,0', 'fr')).toBeCloseTo(2342.0, 20);
-    expect(getNumber('+20 000', 'fr')).toBeCloseTo(20000, 20);
-    expect(getNumber('+20 000,34', 'fr')).toBeCloseTo(20000.34, 20);
-    expect(getNumber('+200 000', 'fr')).toBeCloseTo(200000, 20);
-    expect(getNumber('+2 000 000', 'fr')).toBeCloseTo(2000000, 20);
-    expect(getNumber('+12 054 100,55', 'fr')).toBeCloseTo(12054100.55, 20);
+    expect(getNumber('+0,0', 'fr')).toBeCloseTo(0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+0,45', 'fr')).toBeCloseTo(0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('+0,3', 'fr')).toBeCloseTo(0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('+0,243225', 'fr')).toBeCloseTo(0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('+200', 'fr')).toBeCloseTo(200, supportedNumberOfFractionDigits);
+    expect(getNumber('+200,45', 'fr')).toBeCloseTo(200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('+873,00', 'fr')).toBeCloseTo(873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+2 050', 'fr')).toBeCloseTo(2050, supportedNumberOfFractionDigits);
+    expect(getNumber('+2 000,30', 'fr')).toBeCloseTo(2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('+2 342,0', 'fr')).toBeCloseTo(2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+20 000', 'fr')).toBeCloseTo(20000, supportedNumberOfFractionDigits);
+    expect(getNumber('+20 000,34', 'fr')).toBeCloseTo(20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('+200 000', 'fr')).toBeCloseTo(200000, supportedNumberOfFractionDigits);
+    expect(getNumber('+2 000 000', 'fr')).toBeCloseTo(2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('+12 054 100,55', 'fr')).toBeCloseTo(12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Automatically)(Range: [0, 1]) It should return a possible decimal literal when given an
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr', 0, 0, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -58,7 +61,10 @@ describe('Testing `getNumber` with `fr` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr', 1, 100, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -66,7 +72,10 @@ describe('Testing `getNumber` with `fr` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr', 100, 1000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -74,7 +83,10 @@ describe('Testing `getNumber` with `fr` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr', 1000, 10000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -82,7 +94,10 @@ describe('Testing `getNumber` with `fr` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr', 10000, 100000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -90,7 +105,10 @@ describe('Testing `getNumber` with `fr` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr', 100000, 1000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -98,7 +116,10 @@ describe('Testing `getNumber` with `fr` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr', 1000000, 10000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -106,7 +127,10 @@ describe('Testing `getNumber` with `fr` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr', 10000000, 100000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -114,7 +138,10 @@ describe('Testing `getNumber` with `fr` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr', 100000000, 1000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -122,7 +149,10 @@ describe('Testing `getNumber` with `fr` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr', 1000000000, 10000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -130,7 +160,10 @@ describe('Testing `getNumber` with `fr` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr', 10000000000, 100000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -138,7 +171,10 @@ describe('Testing `getNumber` with `fr` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr', 100000000000, 1000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -146,7 +182,10 @@ describe('Testing `getNumber` with `fr` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr', 1000000000000, 10000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -154,7 +193,10 @@ describe('Testing `getNumber` with `fr` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('fr', 10000000000000, 100000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 });
@@ -162,28 +204,31 @@ describe('Testing `getNumber` with `fr` locale on positive numbers', () => {
 describe('Testing `getNumber` with `fr` locale on negative numbers', () => {
   test(`(Manually) It should return a negative decimal literal when given a
   negative string representation`, () => {
-    expect(getNumber('-0,0', 'fr')).toBeCloseTo(-0.0, 20);
-    expect(getNumber('-0,45', 'fr')).toBeCloseTo(-0.45, 20);
-    expect(getNumber('-0,3', 'fr')).toBeCloseTo(-0.3, 20);
-    expect(getNumber('-0,243225', 'fr')).toBeCloseTo(-0.243225, 20);
-    expect(getNumber('-200', 'fr')).toBeCloseTo(-200, 20);
-    expect(getNumber('-200,45', 'fr')).toBeCloseTo(-200.45, 20);
-    expect(getNumber('-873,00', 'fr')).toBeCloseTo(-873.0, 20);
-    expect(getNumber('-2 050', 'fr')).toBeCloseTo(-2050, 20);
-    expect(getNumber('-2 000,30', 'fr')).toBeCloseTo(-2000.3, 20);
-    expect(getNumber('-2 342,0', 'fr')).toBeCloseTo(-2342.0, 20);
-    expect(getNumber('-20 000', 'fr')).toBeCloseTo(-20000, 20);
-    expect(getNumber('-20 000,34', 'fr')).toBeCloseTo(-20000.34, 20);
-    expect(getNumber('-200 000', 'fr')).toBeCloseTo(-200000, 20);
-    expect(getNumber('-2 000 000', 'fr')).toBeCloseTo(-2000000, 20);
-    expect(getNumber('-12 054 100,55', 'fr')).toBeCloseTo(-12054100.55, 20);
+    expect(getNumber('-0,0', 'fr')).toBeCloseTo(-0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-0,45', 'fr')).toBeCloseTo(-0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('-0,3', 'fr')).toBeCloseTo(-0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('-0,243225', 'fr')).toBeCloseTo(-0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('-200', 'fr')).toBeCloseTo(-200, supportedNumberOfFractionDigits);
+    expect(getNumber('-200,45', 'fr')).toBeCloseTo(-200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('-873,00', 'fr')).toBeCloseTo(-873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-2 050', 'fr')).toBeCloseTo(-2050, supportedNumberOfFractionDigits);
+    expect(getNumber('-2 000,30', 'fr')).toBeCloseTo(-2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('-2 342,0', 'fr')).toBeCloseTo(-2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-20 000', 'fr')).toBeCloseTo(-20000, supportedNumberOfFractionDigits);
+    expect(getNumber('-20 000,34', 'fr')).toBeCloseTo(-20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('-200 000', 'fr')).toBeCloseTo(-200000, supportedNumberOfFractionDigits);
+    expect(getNumber('-2 000 000', 'fr')).toBeCloseTo(-2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('-12 054 100,55', 'fr')).toBeCloseTo(-12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Automatically)(Range: [-1, 0]) It should return a possible decimal literal when given an
   negative string representation`, () => {
     const testCases = testCaseGenerator('fr', 0, -2, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -191,7 +236,10 @@ describe('Testing `getNumber` with `fr` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('fr', -100, -1, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -199,7 +247,10 @@ describe('Testing `getNumber` with `fr` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('fr', -1000, -100, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -207,7 +258,10 @@ describe('Testing `getNumber` with `fr` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('fr', -10000, -1000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -215,7 +269,10 @@ describe('Testing `getNumber` with `fr` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('fr', -100000, -10000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -223,7 +280,10 @@ describe('Testing `getNumber` with `fr` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('fr', -1000000, -100000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -231,7 +291,10 @@ describe('Testing `getNumber` with `fr` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('fr', -10000000, -1000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -239,7 +302,10 @@ describe('Testing `getNumber` with `fr` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('fr', -100000000, -10000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -247,7 +313,10 @@ describe('Testing `getNumber` with `fr` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('fr', -1000000000, -100000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -255,7 +324,10 @@ describe('Testing `getNumber` with `fr` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('fr', -10000000000, -1000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -263,7 +335,10 @@ describe('Testing `getNumber` with `fr` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('fr', -100000000000, -10000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -271,7 +346,10 @@ describe('Testing `getNumber` with `fr` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('fr', -1000000000000, -100000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -279,7 +357,10 @@ describe('Testing `getNumber` with `fr` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('fr', -10000000000000, -1000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'fr')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'fr')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 });

--- a/src/get-number/specs/get-number.hi-in.spec.js
+++ b/src/get-number/specs/get-number.hi-in.spec.js
@@ -1,5 +1,5 @@
 const getNumber = require('../get-number');
-const testCaseGenerator = require('./test-case-generator');
+const { testCaseGenerator, supportedNumberOfFractionDigits } = require('./test-case-generator');
 
 beforeEach(() => {
   // Making sure the `console.error` implementation is empty
@@ -10,47 +10,50 @@ beforeEach(() => {
 describe('Testing `getNumber` with `hi-IN` locale on positive numbers', () => {
   test(`(Manually) It should return a positive decimal literal when given an 
   implicitly positive string representation`, () => {
-    expect(getNumber('0.0', 'hi-IN')).toBeCloseTo(0.0, 20);
-    expect(getNumber('0.45', 'hi-IN')).toBeCloseTo(0.45, 20);
-    expect(getNumber('0.3', 'hi-IN')).toBeCloseTo(0.3, 20);
-    expect(getNumber('0.243225', 'hi-IN')).toBeCloseTo(0.243225, 20);
-    expect(getNumber('200', 'hi-IN')).toBeCloseTo(200, 20);
-    expect(getNumber('200.45', 'hi-IN')).toBeCloseTo(200.45, 20);
-    expect(getNumber('873.00', 'hi-IN')).toBeCloseTo(873.0, 20);
-    expect(getNumber('2,050', 'hi-IN')).toBeCloseTo(2050, 20);
-    expect(getNumber('2,000.30', 'hi-IN')).toBeCloseTo(2000.3, 20);
-    expect(getNumber('2,342.0', 'hi-IN')).toBeCloseTo(2342.0, 20);
-    expect(getNumber('20,000', 'hi-IN')).toBeCloseTo(20000, 20);
-    expect(getNumber('20,000.34', 'hi-IN')).toBeCloseTo(20000.34, 20);
-    expect(getNumber('2,00,000', 'hi-IN')).toBeCloseTo(200000, 20);
-    expect(getNumber('20,00,000', 'hi-IN')).toBeCloseTo(2000000, 20);
-    expect(getNumber('1,20,54,100.55', 'hi-IN')).toBeCloseTo(12054100.55, 20);
+    expect(getNumber('0.0', 'hi-IN')).toBeCloseTo(0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('0.45', 'hi-IN')).toBeCloseTo(0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('0.3', 'hi-IN')).toBeCloseTo(0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('0.243225', 'hi-IN')).toBeCloseTo(0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('200', 'hi-IN')).toBeCloseTo(200, supportedNumberOfFractionDigits);
+    expect(getNumber('200.45', 'hi-IN')).toBeCloseTo(200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('873.00', 'hi-IN')).toBeCloseTo(873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('2,050', 'hi-IN')).toBeCloseTo(2050, supportedNumberOfFractionDigits);
+    expect(getNumber('2,000.30', 'hi-IN')).toBeCloseTo(2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('2,342.0', 'hi-IN')).toBeCloseTo(2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('20,000', 'hi-IN')).toBeCloseTo(20000, supportedNumberOfFractionDigits);
+    expect(getNumber('20,000.34', 'hi-IN')).toBeCloseTo(20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('2,00,000', 'hi-IN')).toBeCloseTo(200000, supportedNumberOfFractionDigits);
+    expect(getNumber('20,00,000', 'hi-IN')).toBeCloseTo(2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('1,20,54,100.55', 'hi-IN')).toBeCloseTo(12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Manually) It should return a positive decimal literal when given an 
   explicitly positive string representation`, () => {
-    expect(getNumber('+0.0', 'hi-IN')).toBeCloseTo(0.0, 20);
-    expect(getNumber('+0.45', 'hi-IN')).toBeCloseTo(0.45, 20);
-    expect(getNumber('+0.3', 'hi-IN')).toBeCloseTo(0.3, 20);
-    expect(getNumber('+0.243225', 'hi-IN')).toBeCloseTo(0.243225, 20);
-    expect(getNumber('+200', 'hi-IN')).toBeCloseTo(200, 20);
-    expect(getNumber('+200.45', 'hi-IN')).toBeCloseTo(200.45, 20);
-    expect(getNumber('+873.00', 'hi-IN')).toBeCloseTo(873.0, 20);
-    expect(getNumber('+2,050', 'hi-IN')).toBeCloseTo(2050, 20);
-    expect(getNumber('+2,000.30', 'hi-IN')).toBeCloseTo(2000.3, 20);
-    expect(getNumber('+2,342.0', 'hi-IN')).toBeCloseTo(2342.0, 20);
-    expect(getNumber('+20,000', 'hi-IN')).toBeCloseTo(20000, 20);
-    expect(getNumber('+20,000.34', 'hi-IN')).toBeCloseTo(20000.34, 20);
-    expect(getNumber('+2,00,000', 'hi-IN')).toBeCloseTo(200000, 20);
-    expect(getNumber('+20,00,000', 'hi-IN')).toBeCloseTo(2000000, 20);
-    expect(getNumber('+1,20,54,100.55', 'hi-IN')).toBeCloseTo(12054100.55, 20);
+    expect(getNumber('+0.0', 'hi-IN')).toBeCloseTo(0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+0.45', 'hi-IN')).toBeCloseTo(0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('+0.3', 'hi-IN')).toBeCloseTo(0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('+0.243225', 'hi-IN')).toBeCloseTo(0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('+200', 'hi-IN')).toBeCloseTo(200, supportedNumberOfFractionDigits);
+    expect(getNumber('+200.45', 'hi-IN')).toBeCloseTo(200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('+873.00', 'hi-IN')).toBeCloseTo(873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+2,050', 'hi-IN')).toBeCloseTo(2050, supportedNumberOfFractionDigits);
+    expect(getNumber('+2,000.30', 'hi-IN')).toBeCloseTo(2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('+2,342.0', 'hi-IN')).toBeCloseTo(2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+20,000', 'hi-IN')).toBeCloseTo(20000, supportedNumberOfFractionDigits);
+    expect(getNumber('+20,000.34', 'hi-IN')).toBeCloseTo(20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('+2,00,000', 'hi-IN')).toBeCloseTo(200000, supportedNumberOfFractionDigits);
+    expect(getNumber('+20,00,000', 'hi-IN')).toBeCloseTo(2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('+1,20,54,100.55', 'hi-IN')).toBeCloseTo(12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Automatically)(Range: [0, 1]) It should return a possible decimal literal when given an
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('hi-IN', 0, 0, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'hi-IN')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'hi-IN')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -58,7 +61,10 @@ describe('Testing `getNumber` with `hi-IN` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('hi-IN', 1, 100, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'hi-IN')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'hi-IN')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -66,7 +72,10 @@ describe('Testing `getNumber` with `hi-IN` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('hi-IN', 100, 1000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'hi-IN')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'hi-IN')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -74,7 +83,10 @@ describe('Testing `getNumber` with `hi-IN` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('hi-IN', 1000, 10000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'hi-IN')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'hi-IN')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -82,7 +94,10 @@ describe('Testing `getNumber` with `hi-IN` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('hi-IN', 10000, 100000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'hi-IN')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'hi-IN')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -90,7 +105,10 @@ describe('Testing `getNumber` with `hi-IN` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('hi-IN', 100000, 1000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'hi-IN')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'hi-IN')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -98,7 +116,10 @@ describe('Testing `getNumber` with `hi-IN` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('hi-IN', 1000000, 10000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'hi-IN')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'hi-IN')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -106,7 +127,10 @@ describe('Testing `getNumber` with `hi-IN` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('hi-IN', 10000000, 100000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'hi-IN')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'hi-IN')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -114,7 +138,10 @@ describe('Testing `getNumber` with `hi-IN` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('hi-IN', 100000000, 1000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'hi-IN')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'hi-IN')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -122,7 +149,10 @@ describe('Testing `getNumber` with `hi-IN` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('hi-IN', 1000000000, 10000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'hi-IN')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'hi-IN')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -130,7 +160,10 @@ describe('Testing `getNumber` with `hi-IN` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('hi-IN', 10000000000, 100000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'hi-IN')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'hi-IN')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -138,7 +171,10 @@ describe('Testing `getNumber` with `hi-IN` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('hi-IN', 100000000000, 1000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'hi-IN')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'hi-IN')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -146,7 +182,10 @@ describe('Testing `getNumber` with `hi-IN` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('hi-IN', 1000000000000, 10000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'hi-IN')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'hi-IN')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -154,7 +193,10 @@ describe('Testing `getNumber` with `hi-IN` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('hi-IN', 10000000000000, 100000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'hi-IN')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'hi-IN')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 });
@@ -162,28 +204,31 @@ describe('Testing `getNumber` with `hi-IN` locale on positive numbers', () => {
 describe('Testing `getNumber` with `hi-IN` locale on negative numbers', () => {
   test(`(Manually) It should return a negative decimal literal when given a
   negative string representation`, () => {
-    expect(getNumber('-0.0', 'hi-IN')).toBeCloseTo(-0.0, 20);
-    expect(getNumber('-0.45', 'hi-IN')).toBeCloseTo(-0.45, 20);
-    expect(getNumber('-0.3', 'hi-IN')).toBeCloseTo(-0.3, 20);
-    expect(getNumber('-0.243225', 'hi-IN')).toBeCloseTo(-0.243225, 20);
-    expect(getNumber('-200', 'hi-IN')).toBeCloseTo(-200, 20);
-    expect(getNumber('-200.45', 'hi-IN')).toBeCloseTo(-200.45, 20);
-    expect(getNumber('-873.00', 'hi-IN')).toBeCloseTo(-873.0, 20);
-    expect(getNumber('-2,050', 'hi-IN')).toBeCloseTo(-2050, 20);
-    expect(getNumber('-2,000.30', 'hi-IN')).toBeCloseTo(-2000.3, 20);
-    expect(getNumber('-2,342.0', 'hi-IN')).toBeCloseTo(-2342.0, 20);
-    expect(getNumber('-20,000', 'hi-IN')).toBeCloseTo(-20000, 20);
-    expect(getNumber('-20,000.34', 'hi-IN')).toBeCloseTo(-20000.34, 20);
-    expect(getNumber('-2,00,000', 'hi-IN')).toBeCloseTo(-200000, 20);
-    expect(getNumber('-20,00,000', 'hi-IN')).toBeCloseTo(-2000000, 20);
-    expect(getNumber('-1,20,54,100.55', 'hi-IN')).toBeCloseTo(-12054100.55, 20);
+    expect(getNumber('-0.0', 'hi-IN')).toBeCloseTo(-0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-0.45', 'hi-IN')).toBeCloseTo(-0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('-0.3', 'hi-IN')).toBeCloseTo(-0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('-0.243225', 'hi-IN')).toBeCloseTo(-0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('-200', 'hi-IN')).toBeCloseTo(-200, supportedNumberOfFractionDigits);
+    expect(getNumber('-200.45', 'hi-IN')).toBeCloseTo(-200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('-873.00', 'hi-IN')).toBeCloseTo(-873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-2,050', 'hi-IN')).toBeCloseTo(-2050, supportedNumberOfFractionDigits);
+    expect(getNumber('-2,000.30', 'hi-IN')).toBeCloseTo(-2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('-2,342.0', 'hi-IN')).toBeCloseTo(-2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-20,000', 'hi-IN')).toBeCloseTo(-20000, supportedNumberOfFractionDigits);
+    expect(getNumber('-20,000.34', 'hi-IN')).toBeCloseTo(-20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('-2,00,000', 'hi-IN')).toBeCloseTo(-200000, supportedNumberOfFractionDigits);
+    expect(getNumber('-20,00,000', 'hi-IN')).toBeCloseTo(-2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('-1,20,54,100.55', 'hi-IN')).toBeCloseTo(-12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Automatically)(Range: [-1, 0]) It should return a possible decimal literal when given an
   negative string representation`, () => {
     const testCases = testCaseGenerator('hi-IN', 0, -2, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'hi-IN')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'hi-IN')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -191,7 +236,10 @@ describe('Testing `getNumber` with `hi-IN` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('hi-IN', -100, -1, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'hi-IN')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'hi-IN')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -199,7 +247,10 @@ describe('Testing `getNumber` with `hi-IN` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('hi-IN', -1000, -100, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'hi-IN')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'hi-IN')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -207,7 +258,10 @@ describe('Testing `getNumber` with `hi-IN` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('hi-IN', -10000, -1000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'hi-IN')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'hi-IN')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -215,7 +269,10 @@ describe('Testing `getNumber` with `hi-IN` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('hi-IN', -100000, -10000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'hi-IN')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'hi-IN')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -223,7 +280,10 @@ describe('Testing `getNumber` with `hi-IN` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('hi-IN', -1000000, -100000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'hi-IN')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'hi-IN')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -231,7 +291,10 @@ describe('Testing `getNumber` with `hi-IN` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('hi-IN', -10000000, -1000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'hi-IN')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'hi-IN')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -239,7 +302,10 @@ describe('Testing `getNumber` with `hi-IN` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('hi-IN', -100000000, -10000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'hi-IN')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'hi-IN')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -247,7 +313,10 @@ describe('Testing `getNumber` with `hi-IN` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('hi-IN', -1000000000, -100000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'hi-IN')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'hi-IN')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -255,7 +324,10 @@ describe('Testing `getNumber` with `hi-IN` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('hi-IN', -10000000000, -1000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'hi-IN')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'hi-IN')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -263,7 +335,10 @@ describe('Testing `getNumber` with `hi-IN` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('hi-IN', -100000000000, -10000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'hi-IN')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'hi-IN')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -271,7 +346,10 @@ describe('Testing `getNumber` with `hi-IN` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('hi-IN', -1000000000000, -100000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'hi-IN')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'hi-IN')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -279,7 +357,10 @@ describe('Testing `getNumber` with `hi-IN` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('hi-IN', -10000000000000, -1000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'hi-IN')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'hi-IN')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 });

--- a/src/get-number/specs/get-number.hi.spec.js
+++ b/src/get-number/specs/get-number.hi.spec.js
@@ -1,5 +1,5 @@
 const getNumber = require('../get-number');
-const testCaseGenerator = require('./test-case-generator');
+const { testCaseGenerator, supportedNumberOfFractionDigits } = require('./test-case-generator');
 
 beforeEach(() => {
   // Making sure the `console.error` implementation is empty
@@ -10,47 +10,50 @@ beforeEach(() => {
 describe('Testing `getNumber` with `hi` locale on positive numbers', () => {
   test(`(Manually) It should return a positive decimal literal when given an 
   implicitly positive string representation`, () => {
-    expect(getNumber('0.0', 'hi')).toBeCloseTo(0.0, 20);
-    expect(getNumber('0.45', 'hi')).toBeCloseTo(0.45, 20);
-    expect(getNumber('0.3', 'hi')).toBeCloseTo(0.3, 20);
-    expect(getNumber('0.243225', 'hi')).toBeCloseTo(0.243225, 20);
-    expect(getNumber('200', 'hi')).toBeCloseTo(200, 20);
-    expect(getNumber('200.45', 'hi')).toBeCloseTo(200.45, 20);
-    expect(getNumber('873.00', 'hi')).toBeCloseTo(873.0, 20);
-    expect(getNumber('2,050', 'hi')).toBeCloseTo(2050, 20);
-    expect(getNumber('2,000.30', 'hi')).toBeCloseTo(2000.3, 20);
-    expect(getNumber('2,342.0', 'hi')).toBeCloseTo(2342.0, 20);
-    expect(getNumber('20,000', 'hi')).toBeCloseTo(20000, 20);
-    expect(getNumber('20,000.34', 'hi')).toBeCloseTo(20000.34, 20);
-    expect(getNumber('2,00,000', 'hi')).toBeCloseTo(200000, 20);
-    expect(getNumber('20,00,000', 'hi')).toBeCloseTo(2000000, 20);
-    expect(getNumber('1,20,54,100.55', 'hi')).toBeCloseTo(12054100.55, 20);
+    expect(getNumber('0.0', 'hi')).toBeCloseTo(0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('0.45', 'hi')).toBeCloseTo(0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('0.3', 'hi')).toBeCloseTo(0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('0.243225', 'hi')).toBeCloseTo(0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('200', 'hi')).toBeCloseTo(200, supportedNumberOfFractionDigits);
+    expect(getNumber('200.45', 'hi')).toBeCloseTo(200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('873.00', 'hi')).toBeCloseTo(873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('2,050', 'hi')).toBeCloseTo(2050, supportedNumberOfFractionDigits);
+    expect(getNumber('2,000.30', 'hi')).toBeCloseTo(2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('2,342.0', 'hi')).toBeCloseTo(2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('20,000', 'hi')).toBeCloseTo(20000, supportedNumberOfFractionDigits);
+    expect(getNumber('20,000.34', 'hi')).toBeCloseTo(20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('2,00,000', 'hi')).toBeCloseTo(200000, supportedNumberOfFractionDigits);
+    expect(getNumber('20,00,000', 'hi')).toBeCloseTo(2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('1,20,54,100.55', 'hi')).toBeCloseTo(12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Manually) It should return a positive decimal literal when given an 
   explicitly positive string representation`, () => {
-    expect(getNumber('+0.0', 'hi')).toBeCloseTo(0.0, 20);
-    expect(getNumber('+0.45', 'hi')).toBeCloseTo(0.45, 20);
-    expect(getNumber('+0.3', 'hi')).toBeCloseTo(0.3, 20);
-    expect(getNumber('+0.243225', 'hi')).toBeCloseTo(0.243225, 20);
-    expect(getNumber('+200', 'hi')).toBeCloseTo(200, 20);
-    expect(getNumber('+200.45', 'hi')).toBeCloseTo(200.45, 20);
-    expect(getNumber('+873.00', 'hi')).toBeCloseTo(873.0, 20);
-    expect(getNumber('+2,050', 'hi')).toBeCloseTo(2050, 20);
-    expect(getNumber('+2,000.30', 'hi')).toBeCloseTo(2000.3, 20);
-    expect(getNumber('+2,342.0', 'hi')).toBeCloseTo(2342.0, 20);
-    expect(getNumber('+20,000', 'hi')).toBeCloseTo(20000, 20);
-    expect(getNumber('+20,000.34', 'hi')).toBeCloseTo(20000.34, 20);
-    expect(getNumber('+2,00,000', 'hi')).toBeCloseTo(200000, 20);
-    expect(getNumber('+20,00,000', 'hi')).toBeCloseTo(2000000, 20);
-    expect(getNumber('+1,20,54,100.55', 'hi')).toBeCloseTo(12054100.55, 20);
+    expect(getNumber('+0.0', 'hi')).toBeCloseTo(0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+0.45', 'hi')).toBeCloseTo(0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('+0.3', 'hi')).toBeCloseTo(0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('+0.243225', 'hi')).toBeCloseTo(0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('+200', 'hi')).toBeCloseTo(200, supportedNumberOfFractionDigits);
+    expect(getNumber('+200.45', 'hi')).toBeCloseTo(200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('+873.00', 'hi')).toBeCloseTo(873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+2,050', 'hi')).toBeCloseTo(2050, supportedNumberOfFractionDigits);
+    expect(getNumber('+2,000.30', 'hi')).toBeCloseTo(2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('+2,342.0', 'hi')).toBeCloseTo(2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+20,000', 'hi')).toBeCloseTo(20000, supportedNumberOfFractionDigits);
+    expect(getNumber('+20,000.34', 'hi')).toBeCloseTo(20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('+2,00,000', 'hi')).toBeCloseTo(200000, supportedNumberOfFractionDigits);
+    expect(getNumber('+20,00,000', 'hi')).toBeCloseTo(2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('+1,20,54,100.55', 'hi')).toBeCloseTo(12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Automatically)(Range: [0, 1]) It should return a possible decimal literal when given an
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('hi', 0, 0, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'hi')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'hi')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -58,7 +61,10 @@ describe('Testing `getNumber` with `hi` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('hi', 1, 100, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'hi')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'hi')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -66,7 +72,10 @@ describe('Testing `getNumber` with `hi` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('hi', 100, 1000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'hi')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'hi')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -74,7 +83,10 @@ describe('Testing `getNumber` with `hi` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('hi', 1000, 10000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'hi')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'hi')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -82,7 +94,10 @@ describe('Testing `getNumber` with `hi` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('hi', 10000, 100000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'hi')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'hi')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -90,7 +105,10 @@ describe('Testing `getNumber` with `hi` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('hi', 100000, 1000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'hi')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'hi')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -98,7 +116,10 @@ describe('Testing `getNumber` with `hi` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('hi', 1000000, 10000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'hi')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'hi')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -106,7 +127,10 @@ describe('Testing `getNumber` with `hi` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('hi', 10000000, 100000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'hi')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'hi')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -114,7 +138,10 @@ describe('Testing `getNumber` with `hi` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('hi', 100000000, 1000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'hi')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'hi')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -122,7 +149,10 @@ describe('Testing `getNumber` with `hi` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('hi', 1000000000, 10000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'hi')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'hi')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -130,7 +160,10 @@ describe('Testing `getNumber` with `hi` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('hi', 10000000000, 100000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'hi')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'hi')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -138,7 +171,10 @@ describe('Testing `getNumber` with `hi` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('hi', 100000000000, 1000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'hi')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'hi')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -146,7 +182,10 @@ describe('Testing `getNumber` with `hi` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('hi', 1000000000000, 10000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'hi')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'hi')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -154,7 +193,10 @@ describe('Testing `getNumber` with `hi` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('hi', 10000000000000, 100000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'hi')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'hi')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 });
@@ -162,28 +204,31 @@ describe('Testing `getNumber` with `hi` locale on positive numbers', () => {
 describe('Testing `getNumber` with `hi` locale on negative numbers', () => {
   test(`(Manually) It should return a negative decimal literal when given a
   negative string representation`, () => {
-    expect(getNumber('-0.0', 'hi')).toBeCloseTo(-0.0, 20);
-    expect(getNumber('-0.45', 'hi')).toBeCloseTo(-0.45, 20);
-    expect(getNumber('-0.3', 'hi')).toBeCloseTo(-0.3, 20);
-    expect(getNumber('-0.243225', 'hi')).toBeCloseTo(-0.243225, 20);
-    expect(getNumber('-200', 'hi')).toBeCloseTo(-200, 20);
-    expect(getNumber('-200.45', 'hi')).toBeCloseTo(-200.45, 20);
-    expect(getNumber('-873.00', 'hi')).toBeCloseTo(-873.0, 20);
-    expect(getNumber('-2,050', 'hi')).toBeCloseTo(-2050, 20);
-    expect(getNumber('-2,000.30', 'hi')).toBeCloseTo(-2000.3, 20);
-    expect(getNumber('-2,342.0', 'hi')).toBeCloseTo(-2342.0, 20);
-    expect(getNumber('-20,000', 'hi')).toBeCloseTo(-20000, 20);
-    expect(getNumber('-20,000.34', 'hi')).toBeCloseTo(-20000.34, 20);
-    expect(getNumber('-2,00,000', 'hi')).toBeCloseTo(-200000, 20);
-    expect(getNumber('-20,00,000', 'hi')).toBeCloseTo(-2000000, 20);
-    expect(getNumber('-1,20,54,100.55', 'hi')).toBeCloseTo(-12054100.55, 20);
+    expect(getNumber('-0.0', 'hi')).toBeCloseTo(-0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-0.45', 'hi')).toBeCloseTo(-0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('-0.3', 'hi')).toBeCloseTo(-0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('-0.243225', 'hi')).toBeCloseTo(-0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('-200', 'hi')).toBeCloseTo(-200, supportedNumberOfFractionDigits);
+    expect(getNumber('-200.45', 'hi')).toBeCloseTo(-200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('-873.00', 'hi')).toBeCloseTo(-873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-2,050', 'hi')).toBeCloseTo(-2050, supportedNumberOfFractionDigits);
+    expect(getNumber('-2,000.30', 'hi')).toBeCloseTo(-2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('-2,342.0', 'hi')).toBeCloseTo(-2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-20,000', 'hi')).toBeCloseTo(-20000, supportedNumberOfFractionDigits);
+    expect(getNumber('-20,000.34', 'hi')).toBeCloseTo(-20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('-2,00,000', 'hi')).toBeCloseTo(-200000, supportedNumberOfFractionDigits);
+    expect(getNumber('-20,00,000', 'hi')).toBeCloseTo(-2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('-1,20,54,100.55', 'hi')).toBeCloseTo(-12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Automatically)(Range: [-1, 0]) It should return a possible decimal literal when given an
   negative string representation`, () => {
     const testCases = testCaseGenerator('hi', 0, -2, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'hi')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'hi')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -191,7 +236,10 @@ describe('Testing `getNumber` with `hi` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('hi', -100, -1, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'hi')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'hi')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -199,7 +247,10 @@ describe('Testing `getNumber` with `hi` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('hi', -1000, -100, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'hi')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'hi')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -207,7 +258,10 @@ describe('Testing `getNumber` with `hi` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('hi', -10000, -1000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'hi')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'hi')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -215,7 +269,10 @@ describe('Testing `getNumber` with `hi` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('hi', -100000, -10000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'hi')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'hi')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -223,7 +280,10 @@ describe('Testing `getNumber` with `hi` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('hi', -1000000, -100000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'hi')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'hi')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -231,7 +291,10 @@ describe('Testing `getNumber` with `hi` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('hi', -10000000, -1000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'hi')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'hi')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -239,7 +302,10 @@ describe('Testing `getNumber` with `hi` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('hi', -100000000, -10000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'hi')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'hi')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -247,7 +313,10 @@ describe('Testing `getNumber` with `hi` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('hi', -1000000000, -100000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'hi')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'hi')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -255,7 +324,10 @@ describe('Testing `getNumber` with `hi` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('hi', -10000000000, -1000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'hi')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'hi')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -263,7 +335,10 @@ describe('Testing `getNumber` with `hi` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('hi', -100000000000, -10000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'hi')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'hi')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -271,7 +346,10 @@ describe('Testing `getNumber` with `hi` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('hi', -1000000000000, -100000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'hi')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'hi')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -279,7 +357,10 @@ describe('Testing `getNumber` with `hi` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('hi', -10000000000000, -1000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'hi')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'hi')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 });

--- a/src/get-number/specs/get-number.ta-in.spec.js
+++ b/src/get-number/specs/get-number.ta-in.spec.js
@@ -1,5 +1,5 @@
 const getNumber = require('../get-number');
-const testCaseGenerator = require('./test-case-generator');
+const { testCaseGenerator, supportedNumberOfFractionDigits } = require('./test-case-generator');
 
 beforeEach(() => {
   // Making sure the `console.error` implementation is empty
@@ -10,47 +10,50 @@ beforeEach(() => {
 describe('Testing `getNumber` with `ta-in` locale on positive numbers', () => {
   test(`(Manually) It should return a positive decimal literal when given an 
   implicitly positive string representation`, () => {
-    expect(getNumber('0.0', 'ta-in')).toBeCloseTo(0.0, 20);
-    expect(getNumber('0.45', 'ta-in')).toBeCloseTo(0.45, 20);
-    expect(getNumber('0.3', 'ta-in')).toBeCloseTo(0.3, 20);
-    expect(getNumber('0.243225', 'ta-in')).toBeCloseTo(0.243225, 20);
-    expect(getNumber('200', 'ta-in')).toBeCloseTo(200, 20);
-    expect(getNumber('200.45', 'ta-in')).toBeCloseTo(200.45, 20);
-    expect(getNumber('873.00', 'ta-in')).toBeCloseTo(873.0, 20);
-    expect(getNumber('2,050', 'ta-in')).toBeCloseTo(2050, 20);
-    expect(getNumber('2,000.30', 'ta-in')).toBeCloseTo(2000.3, 20);
-    expect(getNumber('2,342.0', 'ta-in')).toBeCloseTo(2342.0, 20);
-    expect(getNumber('20,000', 'ta-in')).toBeCloseTo(20000, 20);
-    expect(getNumber('20,000.34', 'ta-in')).toBeCloseTo(20000.34, 20);
-    expect(getNumber('2,00,000', 'ta-in')).toBeCloseTo(200000, 20);
-    expect(getNumber('20,00,000', 'ta-in')).toBeCloseTo(2000000, 20);
-    expect(getNumber('1,20,54,100.55', 'ta-in')).toBeCloseTo(12054100.55, 20);
+    expect(getNumber('0.0', 'ta-in')).toBeCloseTo(0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('0.45', 'ta-in')).toBeCloseTo(0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('0.3', 'ta-in')).toBeCloseTo(0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('0.243225', 'ta-in')).toBeCloseTo(0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('200', 'ta-in')).toBeCloseTo(200, supportedNumberOfFractionDigits);
+    expect(getNumber('200.45', 'ta-in')).toBeCloseTo(200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('873.00', 'ta-in')).toBeCloseTo(873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('2,050', 'ta-in')).toBeCloseTo(2050, supportedNumberOfFractionDigits);
+    expect(getNumber('2,000.30', 'ta-in')).toBeCloseTo(2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('2,342.0', 'ta-in')).toBeCloseTo(2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('20,000', 'ta-in')).toBeCloseTo(20000, supportedNumberOfFractionDigits);
+    expect(getNumber('20,000.34', 'ta-in')).toBeCloseTo(20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('2,00,000', 'ta-in')).toBeCloseTo(200000, supportedNumberOfFractionDigits);
+    expect(getNumber('20,00,000', 'ta-in')).toBeCloseTo(2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('1,20,54,100.55', 'ta-in')).toBeCloseTo(12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Manually) It should return a positive decimal literal when given an 
   explicitly positive string representation`, () => {
-    expect(getNumber('+0.0', 'ta-in')).toBeCloseTo(0.0, 20);
-    expect(getNumber('+0.45', 'ta-in')).toBeCloseTo(0.45, 20);
-    expect(getNumber('+0.3', 'ta-in')).toBeCloseTo(0.3, 20);
-    expect(getNumber('+0.243225', 'ta-in')).toBeCloseTo(0.243225, 20);
-    expect(getNumber('+200', 'ta-in')).toBeCloseTo(200, 20);
-    expect(getNumber('+200.45', 'ta-in')).toBeCloseTo(200.45, 20);
-    expect(getNumber('+873.00', 'ta-in')).toBeCloseTo(873.0, 20);
-    expect(getNumber('+2,050', 'ta-in')).toBeCloseTo(2050, 20);
-    expect(getNumber('+2,000.30', 'ta-in')).toBeCloseTo(2000.3, 20);
-    expect(getNumber('+2,342.0', 'ta-in')).toBeCloseTo(2342.0, 20);
-    expect(getNumber('+20,000', 'ta-in')).toBeCloseTo(20000, 20);
-    expect(getNumber('+20,000.34', 'ta-in')).toBeCloseTo(20000.34, 20);
-    expect(getNumber('+2,00,000', 'ta-in')).toBeCloseTo(200000, 20);
-    expect(getNumber('+20,00,000', 'ta-in')).toBeCloseTo(2000000, 20);
-    expect(getNumber('+1,20,54,100.55', 'ta-in')).toBeCloseTo(12054100.55, 20);
+    expect(getNumber('+0.0', 'ta-in')).toBeCloseTo(0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+0.45', 'ta-in')).toBeCloseTo(0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('+0.3', 'ta-in')).toBeCloseTo(0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('+0.243225', 'ta-in')).toBeCloseTo(0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('+200', 'ta-in')).toBeCloseTo(200, supportedNumberOfFractionDigits);
+    expect(getNumber('+200.45', 'ta-in')).toBeCloseTo(200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('+873.00', 'ta-in')).toBeCloseTo(873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+2,050', 'ta-in')).toBeCloseTo(2050, supportedNumberOfFractionDigits);
+    expect(getNumber('+2,000.30', 'ta-in')).toBeCloseTo(2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('+2,342.0', 'ta-in')).toBeCloseTo(2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+20,000', 'ta-in')).toBeCloseTo(20000, supportedNumberOfFractionDigits);
+    expect(getNumber('+20,000.34', 'ta-in')).toBeCloseTo(20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('+2,00,000', 'ta-in')).toBeCloseTo(200000, supportedNumberOfFractionDigits);
+    expect(getNumber('+20,00,000', 'ta-in')).toBeCloseTo(2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('+1,20,54,100.55', 'ta-in')).toBeCloseTo(12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Automatically)(Range: [0, 1]) It should return a possible decimal literal when given an
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('ta-in', 0, 0, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta-in')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta-in')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -58,7 +61,10 @@ describe('Testing `getNumber` with `ta-in` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('ta-in', 1, 100, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta-in')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta-in')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -66,7 +72,10 @@ describe('Testing `getNumber` with `ta-in` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('ta-in', 100, 1000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta-in')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta-in')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -74,7 +83,10 @@ describe('Testing `getNumber` with `ta-in` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('ta-in', 1000, 10000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta-in')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta-in')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -82,7 +94,10 @@ describe('Testing `getNumber` with `ta-in` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('ta-in', 10000, 100000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta-in')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta-in')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -90,7 +105,10 @@ describe('Testing `getNumber` with `ta-in` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('ta-in', 100000, 1000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta-in')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta-in')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -98,7 +116,10 @@ describe('Testing `getNumber` with `ta-in` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('ta-in', 1000000, 10000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta-in')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta-in')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -106,7 +127,10 @@ describe('Testing `getNumber` with `ta-in` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('ta-in', 10000000, 100000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta-in')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta-in')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -114,7 +138,10 @@ describe('Testing `getNumber` with `ta-in` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('ta-in', 100000000, 1000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta-in')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta-in')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -122,7 +149,10 @@ describe('Testing `getNumber` with `ta-in` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('ta-in', 1000000000, 10000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta-in')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta-in')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -130,7 +160,10 @@ describe('Testing `getNumber` with `ta-in` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('ta-in', 10000000000, 100000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta-in')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta-in')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -138,7 +171,10 @@ describe('Testing `getNumber` with `ta-in` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('ta-in', 100000000000, 1000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta-in')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta-in')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -146,7 +182,10 @@ describe('Testing `getNumber` with `ta-in` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('ta-in', 1000000000000, 10000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta-in')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta-in')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -154,7 +193,10 @@ describe('Testing `getNumber` with `ta-in` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('ta-in', 10000000000000, 100000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta-in')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta-in')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 });
@@ -162,28 +204,31 @@ describe('Testing `getNumber` with `ta-in` locale on positive numbers', () => {
 describe('Testing `getNumber` with `ta-in` locale on negative numbers', () => {
   test(`(Manually) It should return a negative decimal literal when given a
   negative string representation`, () => {
-    expect(getNumber('-0.0', 'ta-in')).toBeCloseTo(-0.0, 20);
-    expect(getNumber('-0.45', 'ta-in')).toBeCloseTo(-0.45, 20);
-    expect(getNumber('-0.3', 'ta-in')).toBeCloseTo(-0.3, 20);
-    expect(getNumber('-0.243225', 'ta-in')).toBeCloseTo(-0.243225, 20);
-    expect(getNumber('-200', 'ta-in')).toBeCloseTo(-200, 20);
-    expect(getNumber('-200.45', 'ta-in')).toBeCloseTo(-200.45, 20);
-    expect(getNumber('-873.00', 'ta-in')).toBeCloseTo(-873.0, 20);
-    expect(getNumber('-2,050', 'ta-in')).toBeCloseTo(-2050, 20);
-    expect(getNumber('-2,000.30', 'ta-in')).toBeCloseTo(-2000.3, 20);
-    expect(getNumber('-2,342.0', 'ta-in')).toBeCloseTo(-2342.0, 20);
-    expect(getNumber('-20,000', 'ta-in')).toBeCloseTo(-20000, 20);
-    expect(getNumber('-20,000.34', 'ta-in')).toBeCloseTo(-20000.34, 20);
-    expect(getNumber('-2,00,000', 'ta-in')).toBeCloseTo(-200000, 20);
-    expect(getNumber('-20,00,000', 'ta-in')).toBeCloseTo(-2000000, 20);
-    expect(getNumber('-1,20,54,100.55', 'ta-in')).toBeCloseTo(-12054100.55, 20);
+    expect(getNumber('-0.0', 'ta-in')).toBeCloseTo(-0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-0.45', 'ta-in')).toBeCloseTo(-0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('-0.3', 'ta-in')).toBeCloseTo(-0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('-0.243225', 'ta-in')).toBeCloseTo(-0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('-200', 'ta-in')).toBeCloseTo(-200, supportedNumberOfFractionDigits);
+    expect(getNumber('-200.45', 'ta-in')).toBeCloseTo(-200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('-873.00', 'ta-in')).toBeCloseTo(-873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-2,050', 'ta-in')).toBeCloseTo(-2050, supportedNumberOfFractionDigits);
+    expect(getNumber('-2,000.30', 'ta-in')).toBeCloseTo(-2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('-2,342.0', 'ta-in')).toBeCloseTo(-2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-20,000', 'ta-in')).toBeCloseTo(-20000, supportedNumberOfFractionDigits);
+    expect(getNumber('-20,000.34', 'ta-in')).toBeCloseTo(-20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('-2,00,000', 'ta-in')).toBeCloseTo(-200000, supportedNumberOfFractionDigits);
+    expect(getNumber('-20,00,000', 'ta-in')).toBeCloseTo(-2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('-1,20,54,100.55', 'ta-in')).toBeCloseTo(-12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Automatically)(Range: [-1, 0]) It should return a possible decimal literal when given an
   negative string representation`, () => {
     const testCases = testCaseGenerator('ta-in', 0, -2, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta-in')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta-in')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -191,7 +236,10 @@ describe('Testing `getNumber` with `ta-in` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('ta-in', -100, -1, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta-in')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta-in')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -199,7 +247,10 @@ describe('Testing `getNumber` with `ta-in` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('ta-in', -1000, -100, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta-in')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta-in')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -207,7 +258,10 @@ describe('Testing `getNumber` with `ta-in` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('ta-in', -10000, -1000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta-in')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta-in')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -215,7 +269,10 @@ describe('Testing `getNumber` with `ta-in` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('ta-in', -100000, -10000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta-in')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta-in')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -223,7 +280,10 @@ describe('Testing `getNumber` with `ta-in` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('ta-in', -1000000, -100000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta-in')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta-in')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -231,7 +291,10 @@ describe('Testing `getNumber` with `ta-in` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('ta-in', -10000000, -1000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta-in')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta-in')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -239,7 +302,10 @@ describe('Testing `getNumber` with `ta-in` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('ta-in', -100000000, -10000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta-in')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta-in')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -247,7 +313,10 @@ describe('Testing `getNumber` with `ta-in` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('ta-in', -1000000000, -100000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta-in')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta-in')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -255,7 +324,10 @@ describe('Testing `getNumber` with `ta-in` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('ta-in', -10000000000, -1000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta-in')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta-in')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -263,7 +335,10 @@ describe('Testing `getNumber` with `ta-in` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('ta-in', -100000000000, -10000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta-in')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta-in')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -271,7 +346,10 @@ describe('Testing `getNumber` with `ta-in` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('ta-in', -1000000000000, -100000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta-in')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta-in')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -279,7 +357,10 @@ describe('Testing `getNumber` with `ta-in` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('ta-in', -10000000000000, -1000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta-in')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta-in')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 });

--- a/src/get-number/specs/get-number.ta-lk.spec.js
+++ b/src/get-number/specs/get-number.ta-lk.spec.js
@@ -1,5 +1,5 @@
 const getNumber = require('../get-number');
-const testCaseGenerator = require('./test-case-generator');
+const { testCaseGenerator, supportedNumberOfFractionDigits } = require('./test-case-generator');
 
 beforeEach(() => {
   // Making sure the `console.error` implementation is empty
@@ -10,47 +10,50 @@ beforeEach(() => {
 describe('Testing `getNumber` with `ta-lk` locale on positive numbers', () => {
   test(`(Manually) It should return a positive decimal literal when given an 
   implicitly positive string representation`, () => {
-    expect(getNumber('0.0', 'ta-lk')).toBeCloseTo(0.0, 20);
-    expect(getNumber('0.45', 'ta-lk')).toBeCloseTo(0.45, 20);
-    expect(getNumber('0.3', 'ta-lk')).toBeCloseTo(0.3, 20);
-    expect(getNumber('0.243225', 'ta-lk')).toBeCloseTo(0.243225, 20);
-    expect(getNumber('200', 'ta-lk')).toBeCloseTo(200, 20);
-    expect(getNumber('200.45', 'ta-lk')).toBeCloseTo(200.45, 20);
-    expect(getNumber('873.00', 'ta-lk')).toBeCloseTo(873.0, 20);
-    expect(getNumber('2,050', 'ta-lk')).toBeCloseTo(2050, 20);
-    expect(getNumber('2,000.30', 'ta-lk')).toBeCloseTo(2000.3, 20);
-    expect(getNumber('2,342.0', 'ta-lk')).toBeCloseTo(2342.0, 20);
-    expect(getNumber('20,000', 'ta-lk')).toBeCloseTo(20000, 20);
-    expect(getNumber('20,000.34', 'ta-lk')).toBeCloseTo(20000.34, 20);
-    expect(getNumber('2,00,000', 'ta-lk')).toBeCloseTo(200000, 20);
-    expect(getNumber('20,00,000', 'ta-lk')).toBeCloseTo(2000000, 20);
-    expect(getNumber('1,20,54,100.55', 'ta-lk')).toBeCloseTo(12054100.55, 20);
+    expect(getNumber('0.0', 'ta-lk')).toBeCloseTo(0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('0.45', 'ta-lk')).toBeCloseTo(0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('0.3', 'ta-lk')).toBeCloseTo(0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('0.243225', 'ta-lk')).toBeCloseTo(0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('200', 'ta-lk')).toBeCloseTo(200, supportedNumberOfFractionDigits);
+    expect(getNumber('200.45', 'ta-lk')).toBeCloseTo(200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('873.00', 'ta-lk')).toBeCloseTo(873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('2,050', 'ta-lk')).toBeCloseTo(2050, supportedNumberOfFractionDigits);
+    expect(getNumber('2,000.30', 'ta-lk')).toBeCloseTo(2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('2,342.0', 'ta-lk')).toBeCloseTo(2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('20,000', 'ta-lk')).toBeCloseTo(20000, supportedNumberOfFractionDigits);
+    expect(getNumber('20,000.34', 'ta-lk')).toBeCloseTo(20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('2,00,000', 'ta-lk')).toBeCloseTo(200000, supportedNumberOfFractionDigits);
+    expect(getNumber('20,00,000', 'ta-lk')).toBeCloseTo(2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('1,20,54,100.55', 'ta-lk')).toBeCloseTo(12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Manually) It should return a positive decimal literal when given an 
   explicitly positive string representation`, () => {
-    expect(getNumber('+0.0', 'ta-lk')).toBeCloseTo(0.0, 20);
-    expect(getNumber('+0.45', 'ta-lk')).toBeCloseTo(0.45, 20);
-    expect(getNumber('+0.3', 'ta-lk')).toBeCloseTo(0.3, 20);
-    expect(getNumber('+0.243225', 'ta-lk')).toBeCloseTo(0.243225, 20);
-    expect(getNumber('+200', 'ta-lk')).toBeCloseTo(200, 20);
-    expect(getNumber('+200.45', 'ta-lk')).toBeCloseTo(200.45, 20);
-    expect(getNumber('+873.00', 'ta-lk')).toBeCloseTo(873.0, 20);
-    expect(getNumber('+2,050', 'ta-lk')).toBeCloseTo(2050, 20);
-    expect(getNumber('+2,000.30', 'ta-lk')).toBeCloseTo(2000.3, 20);
-    expect(getNumber('+2,342.0', 'ta-lk')).toBeCloseTo(2342.0, 20);
-    expect(getNumber('+20,000', 'ta-lk')).toBeCloseTo(20000, 20);
-    expect(getNumber('+20,000.34', 'ta-lk')).toBeCloseTo(20000.34, 20);
-    expect(getNumber('+2,00,000', 'ta-lk')).toBeCloseTo(200000, 20);
-    expect(getNumber('+20,00,000', 'ta-lk')).toBeCloseTo(2000000, 20);
-    expect(getNumber('+1,20,54,100.55', 'ta-lk')).toBeCloseTo(12054100.55, 20);
+    expect(getNumber('+0.0', 'ta-lk')).toBeCloseTo(0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+0.45', 'ta-lk')).toBeCloseTo(0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('+0.3', 'ta-lk')).toBeCloseTo(0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('+0.243225', 'ta-lk')).toBeCloseTo(0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('+200', 'ta-lk')).toBeCloseTo(200, supportedNumberOfFractionDigits);
+    expect(getNumber('+200.45', 'ta-lk')).toBeCloseTo(200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('+873.00', 'ta-lk')).toBeCloseTo(873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+2,050', 'ta-lk')).toBeCloseTo(2050, supportedNumberOfFractionDigits);
+    expect(getNumber('+2,000.30', 'ta-lk')).toBeCloseTo(2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('+2,342.0', 'ta-lk')).toBeCloseTo(2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+20,000', 'ta-lk')).toBeCloseTo(20000, supportedNumberOfFractionDigits);
+    expect(getNumber('+20,000.34', 'ta-lk')).toBeCloseTo(20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('+2,00,000', 'ta-lk')).toBeCloseTo(200000, supportedNumberOfFractionDigits);
+    expect(getNumber('+20,00,000', 'ta-lk')).toBeCloseTo(2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('+1,20,54,100.55', 'ta-lk')).toBeCloseTo(12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Automatically)(Range: [0, 1]) It should return a possible decimal literal when given an
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('ta-lk', 0, 0, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta-lk')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta-lk')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -58,7 +61,10 @@ describe('Testing `getNumber` with `ta-lk` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('ta-lk', 1, 100, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta-lk')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta-lk')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -66,7 +72,10 @@ describe('Testing `getNumber` with `ta-lk` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('ta-lk', 100, 1000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta-lk')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta-lk')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -74,7 +83,10 @@ describe('Testing `getNumber` with `ta-lk` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('ta-lk', 1000, 10000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta-lk')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta-lk')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -82,7 +94,10 @@ describe('Testing `getNumber` with `ta-lk` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('ta-lk', 10000, 100000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta-lk')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta-lk')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -90,7 +105,10 @@ describe('Testing `getNumber` with `ta-lk` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('ta-lk', 100000, 1000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta-lk')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta-lk')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -98,7 +116,10 @@ describe('Testing `getNumber` with `ta-lk` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('ta-lk', 1000000, 10000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta-lk')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta-lk')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -106,7 +127,10 @@ describe('Testing `getNumber` with `ta-lk` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('ta-lk', 10000000, 100000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta-lk')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta-lk')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -114,7 +138,10 @@ describe('Testing `getNumber` with `ta-lk` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('ta-lk', 100000000, 1000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta-lk')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta-lk')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -122,7 +149,10 @@ describe('Testing `getNumber` with `ta-lk` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('ta-lk', 1000000000, 10000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta-lk')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta-lk')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -130,7 +160,10 @@ describe('Testing `getNumber` with `ta-lk` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('ta-lk', 10000000000, 100000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta-lk')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta-lk')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -138,7 +171,10 @@ describe('Testing `getNumber` with `ta-lk` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('ta-lk', 100000000000, 1000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta-lk')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta-lk')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -146,7 +182,10 @@ describe('Testing `getNumber` with `ta-lk` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('ta-lk', 1000000000000, 10000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta-lk')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta-lk')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -154,7 +193,10 @@ describe('Testing `getNumber` with `ta-lk` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('ta-lk', 10000000000000, 100000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta-lk')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta-lk')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 });
@@ -162,28 +204,31 @@ describe('Testing `getNumber` with `ta-lk` locale on positive numbers', () => {
 describe('Testing `getNumber` with `ta-lk` locale on negative numbers', () => {
   test(`(Manually) It should return a negative decimal literal when given a
   negative string representation`, () => {
-    expect(getNumber('-0.0', 'ta-lk')).toBeCloseTo(-0.0, 20);
-    expect(getNumber('-0.45', 'ta-lk')).toBeCloseTo(-0.45, 20);
-    expect(getNumber('-0.3', 'ta-lk')).toBeCloseTo(-0.3, 20);
-    expect(getNumber('-0.243225', 'ta-lk')).toBeCloseTo(-0.243225, 20);
-    expect(getNumber('-200', 'ta-lk')).toBeCloseTo(-200, 20);
-    expect(getNumber('-200.45', 'ta-lk')).toBeCloseTo(-200.45, 20);
-    expect(getNumber('-873.00', 'ta-lk')).toBeCloseTo(-873.0, 20);
-    expect(getNumber('-2,050', 'ta-lk')).toBeCloseTo(-2050, 20);
-    expect(getNumber('-2,000.30', 'ta-lk')).toBeCloseTo(-2000.3, 20);
-    expect(getNumber('-2,342.0', 'ta-lk')).toBeCloseTo(-2342.0, 20);
-    expect(getNumber('-20,000', 'ta-lk')).toBeCloseTo(-20000, 20);
-    expect(getNumber('-20,000.34', 'ta-lk')).toBeCloseTo(-20000.34, 20);
-    expect(getNumber('-2,00,000', 'ta-lk')).toBeCloseTo(-200000, 20);
-    expect(getNumber('-20,00,000', 'ta-lk')).toBeCloseTo(-2000000, 20);
-    expect(getNumber('-1,20,54,100.55', 'ta-lk')).toBeCloseTo(-12054100.55, 20);
+    expect(getNumber('-0.0', 'ta-lk')).toBeCloseTo(-0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-0.45', 'ta-lk')).toBeCloseTo(-0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('-0.3', 'ta-lk')).toBeCloseTo(-0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('-0.243225', 'ta-lk')).toBeCloseTo(-0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('-200', 'ta-lk')).toBeCloseTo(-200, supportedNumberOfFractionDigits);
+    expect(getNumber('-200.45', 'ta-lk')).toBeCloseTo(-200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('-873.00', 'ta-lk')).toBeCloseTo(-873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-2,050', 'ta-lk')).toBeCloseTo(-2050, supportedNumberOfFractionDigits);
+    expect(getNumber('-2,000.30', 'ta-lk')).toBeCloseTo(-2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('-2,342.0', 'ta-lk')).toBeCloseTo(-2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-20,000', 'ta-lk')).toBeCloseTo(-20000, supportedNumberOfFractionDigits);
+    expect(getNumber('-20,000.34', 'ta-lk')).toBeCloseTo(-20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('-2,00,000', 'ta-lk')).toBeCloseTo(-200000, supportedNumberOfFractionDigits);
+    expect(getNumber('-20,00,000', 'ta-lk')).toBeCloseTo(-2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('-1,20,54,100.55', 'ta-lk')).toBeCloseTo(-12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Automatically)(Range: [-1, 0]) It should return a possible decimal literal when given an
   negative string representation`, () => {
     const testCases = testCaseGenerator('ta-lk', 0, -2, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta-lk')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta-lk')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -191,7 +236,10 @@ describe('Testing `getNumber` with `ta-lk` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('ta-lk', -100, -1, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta-lk')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta-lk')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -199,7 +247,10 @@ describe('Testing `getNumber` with `ta-lk` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('ta-lk', -1000, -100, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta-lk')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta-lk')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -207,7 +258,10 @@ describe('Testing `getNumber` with `ta-lk` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('ta-lk', -10000, -1000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta-lk')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta-lk')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -215,7 +269,10 @@ describe('Testing `getNumber` with `ta-lk` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('ta-lk', -100000, -10000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta-lk')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta-lk')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -223,7 +280,10 @@ describe('Testing `getNumber` with `ta-lk` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('ta-lk', -1000000, -100000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta-lk')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta-lk')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -231,7 +291,10 @@ describe('Testing `getNumber` with `ta-lk` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('ta-lk', -10000000, -1000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta-lk')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta-lk')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -239,7 +302,10 @@ describe('Testing `getNumber` with `ta-lk` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('ta-lk', -100000000, -10000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta-lk')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta-lk')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -247,7 +313,10 @@ describe('Testing `getNumber` with `ta-lk` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('ta-lk', -1000000000, -100000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta-lk')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta-lk')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -255,7 +324,10 @@ describe('Testing `getNumber` with `ta-lk` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('ta-lk', -10000000000, -1000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta-lk')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta-lk')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -263,7 +335,10 @@ describe('Testing `getNumber` with `ta-lk` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('ta-lk', -100000000000, -10000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta-lk')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta-lk')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -271,7 +346,10 @@ describe('Testing `getNumber` with `ta-lk` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('ta-lk', -1000000000000, -100000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta-lk')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta-lk')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -279,7 +357,10 @@ describe('Testing `getNumber` with `ta-lk` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('ta-lk', -10000000000000, -1000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta-lk')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta-lk')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 });

--- a/src/get-number/specs/get-number.ta.spec.js
+++ b/src/get-number/specs/get-number.ta.spec.js
@@ -1,5 +1,5 @@
 const getNumber = require('../get-number');
-const testCaseGenerator = require('./test-case-generator');
+const { testCaseGenerator, supportedNumberOfFractionDigits } = require('./test-case-generator');
 
 beforeEach(() => {
   // Making sure the `console.error` implementation is empty
@@ -10,47 +10,50 @@ beforeEach(() => {
 describe('Testing `getNumber` with `ta` locale on positive numbers', () => {
   test(`(Manually) It should return a positive decimal literal when given an 
   implicitly positive string representation`, () => {
-    expect(getNumber('0.0', 'ta')).toBeCloseTo(0.0, 20);
-    expect(getNumber('0.45', 'ta')).toBeCloseTo(0.45, 20);
-    expect(getNumber('0.3', 'ta')).toBeCloseTo(0.3, 20);
-    expect(getNumber('0.243225', 'ta')).toBeCloseTo(0.243225, 20);
-    expect(getNumber('200', 'ta')).toBeCloseTo(200, 20);
-    expect(getNumber('200.45', 'ta')).toBeCloseTo(200.45, 20);
-    expect(getNumber('873.00', 'ta')).toBeCloseTo(873.0, 20);
-    expect(getNumber('2,050', 'ta')).toBeCloseTo(2050, 20);
-    expect(getNumber('2,000.30', 'ta')).toBeCloseTo(2000.3, 20);
-    expect(getNumber('2,342.0', 'ta')).toBeCloseTo(2342.0, 20);
-    expect(getNumber('20,000', 'ta')).toBeCloseTo(20000, 20);
-    expect(getNumber('20,000.34', 'ta')).toBeCloseTo(20000.34, 20);
-    expect(getNumber('2,00,000', 'ta')).toBeCloseTo(200000, 20);
-    expect(getNumber('20,00,000', 'ta')).toBeCloseTo(2000000, 20);
-    expect(getNumber('1,20,54,100.55', 'ta')).toBeCloseTo(12054100.55, 20);
+    expect(getNumber('0.0', 'ta')).toBeCloseTo(0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('0.45', 'ta')).toBeCloseTo(0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('0.3', 'ta')).toBeCloseTo(0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('0.243225', 'ta')).toBeCloseTo(0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('200', 'ta')).toBeCloseTo(200, supportedNumberOfFractionDigits);
+    expect(getNumber('200.45', 'ta')).toBeCloseTo(200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('873.00', 'ta')).toBeCloseTo(873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('2,050', 'ta')).toBeCloseTo(2050, supportedNumberOfFractionDigits);
+    expect(getNumber('2,000.30', 'ta')).toBeCloseTo(2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('2,342.0', 'ta')).toBeCloseTo(2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('20,000', 'ta')).toBeCloseTo(20000, supportedNumberOfFractionDigits);
+    expect(getNumber('20,000.34', 'ta')).toBeCloseTo(20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('2,00,000', 'ta')).toBeCloseTo(200000, supportedNumberOfFractionDigits);
+    expect(getNumber('20,00,000', 'ta')).toBeCloseTo(2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('1,20,54,100.55', 'ta')).toBeCloseTo(12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Manually) It should return a positive decimal literal when given an 
   explicitly positive string representation`, () => {
-    expect(getNumber('+0.0', 'ta')).toBeCloseTo(0.0, 20);
-    expect(getNumber('+0.45', 'ta')).toBeCloseTo(0.45, 20);
-    expect(getNumber('+0.3', 'ta')).toBeCloseTo(0.3, 20);
-    expect(getNumber('+0.243225', 'ta')).toBeCloseTo(0.243225, 20);
-    expect(getNumber('+200', 'ta')).toBeCloseTo(200, 20);
-    expect(getNumber('+200.45', 'ta')).toBeCloseTo(200.45, 20);
-    expect(getNumber('+873.00', 'ta')).toBeCloseTo(873.0, 20);
-    expect(getNumber('+2,050', 'ta')).toBeCloseTo(2050, 20);
-    expect(getNumber('+2,000.30', 'ta')).toBeCloseTo(2000.3, 20);
-    expect(getNumber('+2,342.0', 'ta')).toBeCloseTo(2342.0, 20);
-    expect(getNumber('+20,000', 'ta')).toBeCloseTo(20000, 20);
-    expect(getNumber('+20,000.34', 'ta')).toBeCloseTo(20000.34, 20);
-    expect(getNumber('+2,00,000', 'ta')).toBeCloseTo(200000, 20);
-    expect(getNumber('+20,00,000', 'ta')).toBeCloseTo(2000000, 20);
-    expect(getNumber('+1,20,54,100.55', 'ta')).toBeCloseTo(12054100.55, 20);
+    expect(getNumber('+0.0', 'ta')).toBeCloseTo(0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+0.45', 'ta')).toBeCloseTo(0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('+0.3', 'ta')).toBeCloseTo(0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('+0.243225', 'ta')).toBeCloseTo(0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('+200', 'ta')).toBeCloseTo(200, supportedNumberOfFractionDigits);
+    expect(getNumber('+200.45', 'ta')).toBeCloseTo(200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('+873.00', 'ta')).toBeCloseTo(873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+2,050', 'ta')).toBeCloseTo(2050, supportedNumberOfFractionDigits);
+    expect(getNumber('+2,000.30', 'ta')).toBeCloseTo(2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('+2,342.0', 'ta')).toBeCloseTo(2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+20,000', 'ta')).toBeCloseTo(20000, supportedNumberOfFractionDigits);
+    expect(getNumber('+20,000.34', 'ta')).toBeCloseTo(20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('+2,00,000', 'ta')).toBeCloseTo(200000, supportedNumberOfFractionDigits);
+    expect(getNumber('+20,00,000', 'ta')).toBeCloseTo(2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('+1,20,54,100.55', 'ta')).toBeCloseTo(12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Automatically)(Range: [0, 1]) It should return a possible decimal literal when given an
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('ta', 0, 0, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -58,7 +61,10 @@ describe('Testing `getNumber` with `ta` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('ta', 1, 100, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -66,7 +72,10 @@ describe('Testing `getNumber` with `ta` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('ta', 100, 1000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -74,7 +83,10 @@ describe('Testing `getNumber` with `ta` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('ta', 1000, 10000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -82,7 +94,10 @@ describe('Testing `getNumber` with `ta` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('ta', 10000, 100000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -90,7 +105,10 @@ describe('Testing `getNumber` with `ta` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('ta', 100000, 1000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -98,7 +116,10 @@ describe('Testing `getNumber` with `ta` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('ta', 1000000, 10000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -106,7 +127,10 @@ describe('Testing `getNumber` with `ta` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('ta', 10000000, 100000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -114,7 +138,10 @@ describe('Testing `getNumber` with `ta` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('ta', 100000000, 1000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -122,7 +149,10 @@ describe('Testing `getNumber` with `ta` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('ta', 1000000000, 10000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -130,7 +160,10 @@ describe('Testing `getNumber` with `ta` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('ta', 10000000000, 100000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -138,7 +171,10 @@ describe('Testing `getNumber` with `ta` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('ta', 100000000000, 1000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -146,7 +182,10 @@ describe('Testing `getNumber` with `ta` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('ta', 1000000000000, 10000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -154,7 +193,10 @@ describe('Testing `getNumber` with `ta` locale on positive numbers', () => {
   implicitly positive string representation`, () => {
     const testCases = testCaseGenerator('ta', 10000000000000, 100000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 });
@@ -162,28 +204,31 @@ describe('Testing `getNumber` with `ta` locale on positive numbers', () => {
 describe('Testing `getNumber` with `ta` locale on negative numbers', () => {
   test(`(Manually) It should return a negative decimal literal when given a
   negative string representation`, () => {
-    expect(getNumber('-0.0', 'ta')).toBeCloseTo(-0.0, 20);
-    expect(getNumber('-0.45', 'ta')).toBeCloseTo(-0.45, 20);
-    expect(getNumber('-0.3', 'ta')).toBeCloseTo(-0.3, 20);
-    expect(getNumber('-0.243225', 'ta')).toBeCloseTo(-0.243225, 20);
-    expect(getNumber('-200', 'ta')).toBeCloseTo(-200, 20);
-    expect(getNumber('-200.45', 'ta')).toBeCloseTo(-200.45, 20);
-    expect(getNumber('-873.00', 'ta')).toBeCloseTo(-873.0, 20);
-    expect(getNumber('-2,050', 'ta')).toBeCloseTo(-2050, 20);
-    expect(getNumber('-2,000.30', 'ta')).toBeCloseTo(-2000.3, 20);
-    expect(getNumber('-2,342.0', 'ta')).toBeCloseTo(-2342.0, 20);
-    expect(getNumber('-20,000', 'ta')).toBeCloseTo(-20000, 20);
-    expect(getNumber('-20,000.34', 'ta')).toBeCloseTo(-20000.34, 20);
-    expect(getNumber('-2,00,000', 'ta')).toBeCloseTo(-200000, 20);
-    expect(getNumber('-20,00,000', 'ta')).toBeCloseTo(-2000000, 20);
-    expect(getNumber('-1,20,54,100.55', 'ta')).toBeCloseTo(-12054100.55, 20);
+    expect(getNumber('-0.0', 'ta')).toBeCloseTo(-0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-0.45', 'ta')).toBeCloseTo(-0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('-0.3', 'ta')).toBeCloseTo(-0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('-0.243225', 'ta')).toBeCloseTo(-0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('-200', 'ta')).toBeCloseTo(-200, supportedNumberOfFractionDigits);
+    expect(getNumber('-200.45', 'ta')).toBeCloseTo(-200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('-873.00', 'ta')).toBeCloseTo(-873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-2,050', 'ta')).toBeCloseTo(-2050, supportedNumberOfFractionDigits);
+    expect(getNumber('-2,000.30', 'ta')).toBeCloseTo(-2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('-2,342.0', 'ta')).toBeCloseTo(-2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-20,000', 'ta')).toBeCloseTo(-20000, supportedNumberOfFractionDigits);
+    expect(getNumber('-20,000.34', 'ta')).toBeCloseTo(-20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('-2,00,000', 'ta')).toBeCloseTo(-200000, supportedNumberOfFractionDigits);
+    expect(getNumber('-20,00,000', 'ta')).toBeCloseTo(-2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('-1,20,54,100.55', 'ta')).toBeCloseTo(-12054100.55, supportedNumberOfFractionDigits);
   });
 
   test(`(Automatically)(Range: [-1, 0]) It should return a possible decimal literal when given an
   negative string representation`, () => {
     const testCases = testCaseGenerator('ta', 0, -2, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -191,7 +236,10 @@ describe('Testing `getNumber` with `ta` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('ta', -100, -1, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -199,7 +247,10 @@ describe('Testing `getNumber` with `ta` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('ta', -1000, -100, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -207,7 +258,10 @@ describe('Testing `getNumber` with `ta` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('ta', -10000, -1000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -215,7 +269,10 @@ describe('Testing `getNumber` with `ta` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('ta', -100000, -10000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -223,7 +280,10 @@ describe('Testing `getNumber` with `ta` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('ta', -1000000, -100000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -231,7 +291,10 @@ describe('Testing `getNumber` with `ta` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('ta', -10000000, -1000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -239,7 +302,10 @@ describe('Testing `getNumber` with `ta` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('ta', -100000000, -10000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -247,7 +313,10 @@ describe('Testing `getNumber` with `ta` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('ta', -1000000000, -100000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -255,7 +324,10 @@ describe('Testing `getNumber` with `ta` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('ta', -10000000000, -1000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -263,7 +335,10 @@ describe('Testing `getNumber` with `ta` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('ta', -100000000000, -10000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -271,7 +346,10 @@ describe('Testing `getNumber` with `ta` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('ta', -1000000000000, -100000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 
@@ -279,7 +357,10 @@ describe('Testing `getNumber` with `ta` locale on negative numbers', () => {
   negative string representation`, () => {
     const testCases = testCaseGenerator('ta', -10000000000000, -1000000000000, 1000);
     testCases.forEach((testCase) => {
-      expect(getNumber(testCase.stringRepresentation, 'ta')).toBeCloseTo(testCase.groundTruth, 20);
+      expect(getNumber(testCase.stringRepresentation, 'ta')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
     });
   });
 });

--- a/src/get-number/specs/test-case-generator.js
+++ b/src/get-number/specs/test-case-generator.js
@@ -36,8 +36,8 @@ function testCaseGenerator(locale, from, to, numberOfTestCases) {
       testCases.push({
         groundTruth,
         stringRepresentation: new Intl.NumberFormat(locale.toLowerCase(), {
-          minimumFractionDigits: 20,
-          maximumFractionDigits: 20,
+          minimumFractionDigits: supportedNumberOfFractionDigits + 1,
+          maximumFractionDigits: supportedNumberOfFractionDigits + 1,
         }).format(groundTruth),
       });
     } else {
@@ -45,8 +45,8 @@ function testCaseGenerator(locale, from, to, numberOfTestCases) {
       testCases.push({
         groundTruth,
         stringRepresentation: new Intl.NumberFormat(locale.toLowerCase(), {
-          minimumFractionDigits: 20,
-          maximumFractionDigits: 20,
+          minimumFractionDigits: supportedNumberOfFractionDigits + 1,
+          maximumFractionDigits: supportedNumberOfFractionDigits + 1,
         }).format(groundTruth),
       });
     }
@@ -56,4 +56,11 @@ function testCaseGenerator(locale, from, to, numberOfTestCases) {
   return testCases;
 }
 
-module.exports = testCaseGenerator;
+// We, currently, support up to 19 fraction digits.
+const supportedNumberOfFractionDigits = 19;
+
+module.exports = { 
+  testCaseGenerator,
+  supportedNumberOfFractionDigits
+};
+


### PR DESCRIPTION
# Description

Added explicit variable that holds the exact number of the supported digits. I have, also, fixed an issue where testing was failing due to rounding.

Fixes N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

I have tested the new locale following the instructions from the wiki page.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
