### PR TITLE
Add full no locale support.

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -11,10 +11,10 @@
 function constructExtractionRegex(thousandsSeparator, decimalSeparator, indianNotation = false) {
   if (indianNotation) {
     return new RegExp(
-      `^[+|-]?(([1-9]{1}[0-9]{0,1}${thousandsSeparator})+([0-9]{2}${thousandsSeparator})*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(${decimalSeparator}[0-9]+)?$`
+      `^[\+\-\−]?(([1-9]{1}[0-9]{0,1}${thousandsSeparator})+([0-9]{2}${thousandsSeparator})*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(${decimalSeparator}[0-9]+)?$`
     );
   } else {
-    return new RegExp(`^[+|-]?([1-9]{1}[0-9]{0,2}(${thousandsSeparator}[0-9]{3})*|0)(${decimalSeparator}[0-9]+)?$`);
+    return new RegExp(`^[\+\-\−]?([1-9]{1}[0-9]{0,2}(${thousandsSeparator}[0-9]{3})*|0)(${decimalSeparator}[0-9]+)?$`);
   }
 }
 
@@ -33,7 +33,10 @@ function cleanNumberRepresentation(numberRepresentation, regex, localeConfigurat
     // sure the `decimal` separator is the `dot`.
     const cleanNumberRepresentation = numberRepresentation
       .replace(new RegExp(localeConfiguration.thousands, 'g'), '')
-      .replace(new RegExp(localeConfiguration.decimal), '.');
+      .replace(new RegExp(localeConfiguration.decimal), '.')
+      // This is needed because the `−` characters breaks the
+      // `parseFloat` function.
+      .replace(new RegExp('\−'), '-');
 
     return cleanNumberRepresentation;
   } else {

--- a/src/core/core.spec.js
+++ b/src/core/core.spec.js
@@ -10,50 +10,50 @@ describe('Testing `constructExtractionRegex` function', () => {
   test(`It should construct the extraction regex for non-Indian notation by placing the
       thousand and the decimal separator in the correct places`, () => {
     expect(constructExtractionRegex('\\,', '\\.')).toEqual(
-      new RegExp('^[+|-]?([1-9]{1}[0-9]{0,2}(\\,[0-9]{3})*|0)(\\.[0-9]+)?$')
+      new RegExp('^[\+\-\−]?([1-9]{1}[0-9]{0,2}(\\,[0-9]{3})*|0)(\\.[0-9]+)?$')
     );
 
     expect(constructExtractionRegex('\\.', '\\,')).toEqual(
-      new RegExp('^[+|-]?([1-9]{1}[0-9]{0,2}(\\.[0-9]{3})*|0)(\\,[0-9]+)?$')
+      new RegExp('^[\+\-\−]?([1-9]{1}[0-9]{0,2}(\\.[0-9]{3})*|0)(\\,[0-9]+)?$')
     );
 
     expect(constructExtractionRegex('[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s]', '\\.')).toEqual(
-      new RegExp('^[+|-]?([1-9]{1}[0-9]{0,2}([\\u202F\\u00A0\\u2000\\u2001\\u2003\\s][0-9]{3})*|0)(\\.[0-9]+)?$')
+      new RegExp('^[\+\-\−]?([1-9]{1}[0-9]{0,2}([\\u202F\\u00A0\\u2000\\u2001\\u2003\\s][0-9]{3})*|0)(\\.[0-9]+)?$')
     );
 
     expect(constructExtractionRegex('[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s]', '\\,')).toEqual(
-      new RegExp('^[+|-]?([1-9]{1}[0-9]{0,2}([\\u202F\\u00A0\\u2000\\u2001\\u2003\\s][0-9]{3})*|0)(\\,[0-9]+)?$')
+      new RegExp('^[\+\-\−]?([1-9]{1}[0-9]{0,2}([\\u202F\\u00A0\\u2000\\u2001\\u2003\\s][0-9]{3})*|0)(\\,[0-9]+)?$')
     );
 
     expect(constructExtractionRegex("['΄’]", '\\.')).toEqual(
-      new RegExp("^[+|-]?([1-9]{1}[0-9]{0,2}(['΄’][0-9]{3})*|0)(\\.[0-9]+)?$")
+      new RegExp("^[\+\-\−]?([1-9]{1}[0-9]{0,2}(['΄’][0-9]{3})*|0)(\\.[0-9]+)?$")
     );
   });
 
   test(`It should construct the extraction regex for Indian notation by placing the
       thousand and the decimal separator in the correct places`, () => {
     expect(constructExtractionRegex('\\,', '\\.', true)).toEqual(
-      new RegExp('^[+|-]?(([1-9]{1}[0-9]{0,1}\\,)+([0-9]{2}\\,)*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\.[0-9]+)?$')
+      new RegExp('^[\+\-\−]?(([1-9]{1}[0-9]{0,1}\\,)+([0-9]{2}\\,)*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\.[0-9]+)?$')
     );
 
     expect(constructExtractionRegex('\\.', '\\,', true)).toEqual(
-      new RegExp('^[+|-]?(([1-9]{1}[0-9]{0,1}\\.)+([0-9]{2}\\.)*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\,[0-9]+)?$')
+      new RegExp('^[\+\-\−]?(([1-9]{1}[0-9]{0,1}\\.)+([0-9]{2}\\.)*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\,[0-9]+)?$')
     );
 
     expect(constructExtractionRegex('[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s]', '\\.', true)).toEqual(
       new RegExp(
-        '^[+|-]?(([1-9]{1}[0-9]{0,1}[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s])+([0-9]{2}[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s])*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\.[0-9]+)?$'
+        '^[\+\-\−]?(([1-9]{1}[0-9]{0,1}[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s])+([0-9]{2}[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s])*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\.[0-9]+)?$'
       )
     );
 
     expect(constructExtractionRegex('[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s]', '\\,', true)).toEqual(
       new RegExp(
-        '^[+|-]?(([1-9]{1}[0-9]{0,1}[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s])+([0-9]{2}[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s])*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\,[0-9]+)?$'
+        '^[\+\-\−]?(([1-9]{1}[0-9]{0,1}[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s])+([0-9]{2}[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s])*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\,[0-9]+)?$'
       )
     );
 
     expect(constructExtractionRegex("['΄’]", '\\.', true)).toEqual(
-      new RegExp("^[+|-]?(([1-9]{1}[0-9]{0,1}['΄’])+([0-9]{2}['΄’])*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\.[0-9]+)?$")
+      new RegExp("^[\+\-\−]?(([1-9]{1}[0-9]{0,1}['΄’])+([0-9]{2}['΄’])*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\.[0-9]+)?$")
     );
   });
 });
@@ -65,7 +65,7 @@ describe('Testing `cleanNumber` function', () => {
     const testCases = [
       {
         numberRepresentation: '20.000',
-        regex: new RegExp('^([+|-])?[1-9]{1}[0-9]{0,2}(\\.([0-9]{3}))*(\\,[0-9]+)?$'),
+        regex: new RegExp('^([\+\-\−])?[1-9]{1}[0-9]{0,2}(\\.([0-9]{3}))*(\\,[0-9]+)?$'),
         localeConfiguration: {
           thousands: '\\.',
           decimal: '\\,',
@@ -74,7 +74,7 @@ describe('Testing `cleanNumber` function', () => {
       },
       {
         numberRepresentation: '20.000,5',
-        regex: new RegExp('^([+|-])?[1-9]{1}[0-9]{0,2}(\\.([0-9]{3}))*(\\,[0-9]+)?$'),
+        regex: new RegExp('^([\+\-\−])?[1-9]{1}[0-9]{0,2}(\\.([0-9]{3}))*(\\,[0-9]+)?$'),
         localeConfiguration: {
           thousands: '\\.',
           decimal: '\\,',
@@ -83,7 +83,7 @@ describe('Testing `cleanNumber` function', () => {
       },
       {
         numberRepresentation: '20.000,567',
-        regex: new RegExp('^([+|-])?[1-9]{1}[0-9]{0,2}(\\.([0-9]{3}))*(\\,[0-9]+)?$'),
+        regex: new RegExp('^([\+\-\−])?[1-9]{1}[0-9]{0,2}(\\.([0-9]{3}))*(\\,[0-9]+)?$'),
         localeConfiguration: {
           thousands: '\\.',
           decimal: '\\,',
@@ -92,7 +92,7 @@ describe('Testing `cleanNumber` function', () => {
       },
       {
         numberRepresentation: '200,5',
-        regex: new RegExp('^([+|-])?[1-9]{1}[0-9]{0,2}(\\.([0-9]{3}))*(\\,[0-9]+)?$'),
+        regex: new RegExp('^([\+\-\−])?[1-9]{1}[0-9]{0,2}(\\.([0-9]{3}))*(\\,[0-9]+)?$'),
         localeConfiguration: {
           thousands: '\\.',
           decimal: '\\,',
@@ -101,7 +101,7 @@ describe('Testing `cleanNumber` function', () => {
       },
       {
         numberRepresentation: '1.200,00',
-        regex: new RegExp('^([+|-])?[1-9]{1}[0-9]{0,2}(\\.([0-9]{3}))*(\\,[0-9]+)?$'),
+        regex: new RegExp('^([\+\-\−])?[1-9]{1}[0-9]{0,2}(\\.([0-9]{3}))*(\\,[0-9]+)?$'),
         localeConfiguration: {
           thousands: '\\.',
           decimal: '\\,',
@@ -110,7 +110,7 @@ describe('Testing `cleanNumber` function', () => {
       },
       {
         numberRepresentation: '50',
-        regex: new RegExp('^([+|-])?[1-9]{1}[0-9]{0,2}(\\.([0-9]{3}))*(\\,[0-9]+)?$'),
+        regex: new RegExp('^([\+\-\−])?[1-9]{1}[0-9]{0,2}(\\.([0-9]{3}))*(\\,[0-9]+)?$'),
         localeConfiguration: {
           thousands: '\\.',
           decimal: '\\,',
@@ -119,7 +119,7 @@ describe('Testing `cleanNumber` function', () => {
       },
       {
         numberRepresentation: '20,000',
-        regex: new RegExp('^([+|-])?[1-9]{1}[0-9]{0,2}(\\,([0-9]{3}))*(\\.[0-9]+)?$'),
+        regex: new RegExp('^([\+\-\−])?[1-9]{1}[0-9]{0,2}(\\,([0-9]{3}))*(\\.[0-9]+)?$'),
         localeConfiguration: {
           thousands: '\\,',
           decimal: '\\.',
@@ -128,7 +128,7 @@ describe('Testing `cleanNumber` function', () => {
       },
       {
         numberRepresentation: '20,000.5',
-        regex: new RegExp('^([+|-])?[1-9]{1}[0-9]{0,2}(\\,([0-9]{3}))*(\\.[0-9]+)?$'),
+        regex: new RegExp('^([\+\-\−])?[1-9]{1}[0-9]{0,2}(\\,([0-9]{3}))*(\\.[0-9]+)?$'),
         localeConfiguration: {
           thousands: '\\,',
           decimal: '\\.',
@@ -137,7 +137,7 @@ describe('Testing `cleanNumber` function', () => {
       },
       {
         numberRepresentation: '20,000.567',
-        regex: new RegExp('^([+|-])?[1-9]{1}[0-9]{0,2}(\\,([0-9]{3}))*(\\.[0-9]+)?$'),
+        regex: new RegExp('^([\+\-\−])?[1-9]{1}[0-9]{0,2}(\\,([0-9]{3}))*(\\.[0-9]+)?$'),
         localeConfiguration: {
           thousands: '\\,',
           decimal: '\\.',
@@ -146,7 +146,7 @@ describe('Testing `cleanNumber` function', () => {
       },
       {
         numberRepresentation: '200.5',
-        regex: new RegExp('^([+|-])?[1-9]{1}[0-9]{0,2}(\\,([0-9]{3}))*(\\.[0-9]+)?$'),
+        regex: new RegExp('^([\+\-\−])?[1-9]{1}[0-9]{0,2}(\\,([0-9]{3}))*(\\.[0-9]+)?$'),
         localeConfiguration: {
           thousands: '\\,',
           decimal: '\\.',
@@ -155,7 +155,7 @@ describe('Testing `cleanNumber` function', () => {
       },
       {
         numberRepresentation: '1,200.00',
-        regex: new RegExp('^([+|-])?[1-9]{1}[0-9]{0,2}(\\,([0-9]{3}))*(\\.[0-9]+)?$'),
+        regex: new RegExp('^([\+\-\−])?[1-9]{1}[0-9]{0,2}(\\,([0-9]{3}))*(\\.[0-9]+)?$'),
         localeConfiguration: {
           thousands: '\\,',
           decimal: '\\.',
@@ -164,7 +164,7 @@ describe('Testing `cleanNumber` function', () => {
       },
       {
         numberRepresentation: '50',
-        regex: new RegExp('^([+|-])?[1-9]{1}[0-9]{0,2}(\\,([0-9]{3}))*(\\.[0-9]+)?$'),
+        regex: new RegExp('^([\+\-\−])?[1-9]{1}[0-9]{0,2}(\\,([0-9]{3}))*(\\.[0-9]+)?$'),
         localeConfiguration: {
           thousands: '\\,',
           decimal: '\\.',
@@ -174,7 +174,7 @@ describe('Testing `cleanNumber` function', () => {
       {
         numberRepresentation: '20 000',
         regex: new RegExp(
-          '^([+|-])?[1-9]{1}[0-9]{0,2}([\\u202F\\u00A0\\u2000\\u2001\\u2003\\s]([0-9]{3}))*(\\.[0-9]+)?$'
+          '^([\+\-\−])?[1-9]{1}[0-9]{0,2}([\\u202F\\u00A0\\u2000\\u2001\\u2003\\s]([0-9]{3}))*(\\.[0-9]+)?$'
         ),
         localeConfiguration: {
           thousands: '[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s]',
@@ -185,7 +185,7 @@ describe('Testing `cleanNumber` function', () => {
       {
         numberRepresentation: '20 000.5',
         regex: new RegExp(
-          '^([+|-])?[1-9]{1}[0-9]{0,2}([\\u202F\\u00A0\\u2000\\u2001\\u2003\\s]([0-9]{3}))*(\\.[0-9]+)?$'
+          '^([\+\-\−])?[1-9]{1}[0-9]{0,2}([\\u202F\\u00A0\\u2000\\u2001\\u2003\\s]([0-9]{3}))*(\\.[0-9]+)?$'
         ),
         localeConfiguration: {
           thousands: '[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s]',
@@ -196,7 +196,7 @@ describe('Testing `cleanNumber` function', () => {
       {
         numberRepresentation: '20 000.567',
         regex: new RegExp(
-          '^([+|-])?[1-9]{1}[0-9]{0,2}([\\u202F\\u00A0\\u2000\\u2001\\u2003\\s]([0-9]{3}))*(\\.[0-9]+)?$'
+          '^([\+\-\−])?[1-9]{1}[0-9]{0,2}([\\u202F\\u00A0\\u2000\\u2001\\u2003\\s]([0-9]{3}))*(\\.[0-9]+)?$'
         ),
         localeConfiguration: {
           thousands: '[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s]',
@@ -207,7 +207,7 @@ describe('Testing `cleanNumber` function', () => {
       {
         numberRepresentation: '200.5',
         regex: new RegExp(
-          '^([+|-])?[1-9]{1}[0-9]{0,2}([\\u202F\\u00A0\\u2000\\u2001\\u2003\\s]([0-9]{3}))*(\\.[0-9]+)?$'
+          '^([\+\-\−])?[1-9]{1}[0-9]{0,2}([\\u202F\\u00A0\\u2000\\u2001\\u2003\\s]([0-9]{3}))*(\\.[0-9]+)?$'
         ),
         localeConfiguration: {
           thousands: '[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s]',
@@ -218,7 +218,7 @@ describe('Testing `cleanNumber` function', () => {
       {
         numberRepresentation: '1 200.00',
         regex: new RegExp(
-          '^([+|-])?[1-9]{1}[0-9]{0,2}([\\u202F\\u00A0\\u2000\\u2001\\u2003\\s]([0-9]{3}))*(\\.[0-9]+)?$'
+          '^([\+\-\−])?[1-9]{1}[0-9]{0,2}([\\u202F\\u00A0\\u2000\\u2001\\u2003\\s]([0-9]{3}))*(\\.[0-9]+)?$'
         ),
         localeConfiguration: {
           thousands: '[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s]',
@@ -229,7 +229,7 @@ describe('Testing `cleanNumber` function', () => {
       {
         numberRepresentation: '50',
         regex: new RegExp(
-          '^([+|-])?[1-9]{1}[0-9]{0,2}([\\u202F\\u00A0\\u2000\\u2001\\u2003\\s]([0-9]{3}))*(\\.[0-9]+)?$'
+          '^([\+\-\−])?[1-9]{1}[0-9]{0,2}([\\u202F\\u00A0\\u2000\\u2001\\u2003\\s]([0-9]{3}))*(\\.[0-9]+)?$'
         ),
         localeConfiguration: {
           thousands: '[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s]',
@@ -240,7 +240,7 @@ describe('Testing `cleanNumber` function', () => {
       {
         numberRepresentation: '20 000',
         regex: new RegExp(
-          '^([+|-])?[1-9]{1}[0-9]{0,2}([\\u202F\\u00A0\\u2000\\u2001\\u2003\\s]([0-9]{3}))*(\\,[0-9]+)?$'
+          '^([\+\-\−])?[1-9]{1}[0-9]{0,2}([\\u202F\\u00A0\\u2000\\u2001\\u2003\\s]([0-9]{3}))*(\\,[0-9]+)?$'
         ),
         localeConfiguration: {
           thousands: '[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s]',
@@ -251,7 +251,7 @@ describe('Testing `cleanNumber` function', () => {
       {
         numberRepresentation: '20 000,5',
         regex: new RegExp(
-          '^([+|-])?[1-9]{1}[0-9]{0,2}([\\u202F\\u00A0\\u2000\\u2001\\u2003\\s]([0-9]{3}))*(\\,[0-9]+)?$'
+          '^([\+\-\−])?[1-9]{1}[0-9]{0,2}([\\u202F\\u00A0\\u2000\\u2001\\u2003\\s]([0-9]{3}))*(\\,[0-9]+)?$'
         ),
         localeConfiguration: {
           thousands: '[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s]',
@@ -262,7 +262,7 @@ describe('Testing `cleanNumber` function', () => {
       {
         numberRepresentation: '20 000,567',
         regex: new RegExp(
-          '^([+|-])?[1-9]{1}[0-9]{0,2}([\\u202F\\u00A0\\u2000\\u2001\\u2003\\s]([0-9]{3}))*(\\,[0-9]+)?$'
+          '^([\+\-\−])?[1-9]{1}[0-9]{0,2}([\\u202F\\u00A0\\u2000\\u2001\\u2003\\s]([0-9]{3}))*(\\,[0-9]+)?$'
         ),
         localeConfiguration: {
           thousands: '[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s]',
@@ -273,7 +273,7 @@ describe('Testing `cleanNumber` function', () => {
       {
         numberRepresentation: '200,5',
         regex: new RegExp(
-          '^([+|-])?[1-9]{1}[0-9]{0,2}([\\u202F\\u00A0\\u2000\\u2001\\u2003\\s]([0-9]{3}))*(\\,[0-9]+)?$'
+          '^([\+\-\−])?[1-9]{1}[0-9]{0,2}([\\u202F\\u00A0\\u2000\\u2001\\u2003\\s]([0-9]{3}))*(\\,[0-9]+)?$'
         ),
         localeConfiguration: {
           thousands: '[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s]',
@@ -284,7 +284,7 @@ describe('Testing `cleanNumber` function', () => {
       {
         numberRepresentation: '1 200,00',
         regex: new RegExp(
-          '^([+|-])?[1-9]{1}[0-9]{0,2}([\\u202F\\u00A0\\u2000\\u2001\\u2003\\s]([0-9]{3}))*(\\,[0-9]+)?$'
+          '^([\+\-\−])?[1-9]{1}[0-9]{0,2}([\\u202F\\u00A0\\u2000\\u2001\\u2003\\s]([0-9]{3}))*(\\,[0-9]+)?$'
         ),
         localeConfiguration: {
           thousands: '[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s]',
@@ -295,7 +295,7 @@ describe('Testing `cleanNumber` function', () => {
       {
         numberRepresentation: '50',
         regex: new RegExp(
-          '^([+|-])?[1-9]{1}[0-9]{0,2}([\\u202F\\u00A0\\u2000\\u2001\\u2003\\s]([0-9]{3}))*(\\,[0-9]+)?$'
+          '^([\+\-\−])?[1-9]{1}[0-9]{0,2}([\\u202F\\u00A0\\u2000\\u2001\\u2003\\s]([0-9]{3}))*(\\,[0-9]+)?$'
         ),
         localeConfiguration: {
           thousands: '[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s]',
@@ -305,7 +305,7 @@ describe('Testing `cleanNumber` function', () => {
       },
       {
         numberRepresentation: "20'000",
-        regex: new RegExp("^([+|-])?[1-9]{1}[0-9]{0,2}(['΄’]([0-9]{3}))*(\\.[0-9]+)?$"),
+        regex: new RegExp("^([\+\-\−])?[1-9]{1}[0-9]{0,2}(['΄’]([0-9]{3}))*(\\.[0-9]+)?$"),
         localeConfiguration: {
           thousands: "'",
           decimal: "['΄’]",
@@ -314,7 +314,7 @@ describe('Testing `cleanNumber` function', () => {
       },
       {
         numberRepresentation: "20'000.5",
-        regex: new RegExp("^([+|-])?[1-9]{1}[0-9]{0,2}(['΄’]([0-9]{3}))*(\\.[0-9]+)?$"),
+        regex: new RegExp("^([\+\-\−])?[1-9]{1}[0-9]{0,2}(['΄’]([0-9]{3}))*(\\.[0-9]+)?$"),
         localeConfiguration: {
           thousands: "['΄’]",
           decimal: '\\.',
@@ -323,7 +323,7 @@ describe('Testing `cleanNumber` function', () => {
       },
       {
         numberRepresentation: "20'000.567",
-        regex: new RegExp("^([+|-])?[1-9]{1}[0-9]{0,2}(['΄’]([0-9]{3}))*(\\.[0-9]+)?$"),
+        regex: new RegExp("^([\+\-\−])?[1-9]{1}[0-9]{0,2}(['΄’]([0-9]{3}))*(\\.[0-9]+)?$"),
         localeConfiguration: {
           thousands: "['΄’]",
           decimal: '\\.',
@@ -332,7 +332,7 @@ describe('Testing `cleanNumber` function', () => {
       },
       {
         numberRepresentation: '200.5',
-        regex: new RegExp("^([+|-])?[1-9]{1}[0-9]{0,2}(['΄’]([0-9]{3}))*(\\.[0-9]+)?$"),
+        regex: new RegExp("^([\+\-\−])?[1-9]{1}[0-9]{0,2}(['΄’]([0-9]{3}))*(\\.[0-9]+)?$"),
         localeConfiguration: {
           thousands: "['΄’]",
           decimal: '\\.',
@@ -341,7 +341,7 @@ describe('Testing `cleanNumber` function', () => {
       },
       {
         numberRepresentation: "1'200.00",
-        regex: new RegExp("^([+|-])?[1-9]{1}[0-9]{0,2}(['΄’]([0-9]{3}))*(\\.[0-9]+)?$"),
+        regex: new RegExp("^([\+\-\−])?[1-9]{1}[0-9]{0,2}(['΄’]([0-9]{3}))*(\\.[0-9]+)?$"),
         localeConfiguration: {
           thousands: "['΄’]",
           decimal: '\\.',
@@ -350,7 +350,7 @@ describe('Testing `cleanNumber` function', () => {
       },
       {
         numberRepresentation: '50',
-        regex: new RegExp("^([+|-])?[1-9]{1}[0-9]{0,2}(['΄’]([0-9]{3}))*(\\.[0-9]+)?$"),
+        regex: new RegExp("^([\+\-\−])?[1-9]{1}[0-9]{0,2}(['΄’]([0-9]{3}))*(\\.[0-9]+)?$"),
         localeConfiguration: {
           thousands: "['΄’]",
           decimal: '\\.',
@@ -359,7 +359,7 @@ describe('Testing `cleanNumber` function', () => {
       },
       {
         numberRepresentation: "20'000",
-        regex: new RegExp("^([+|-])?[1-9]{1}[0-9]{0,2}(['΄’]([0-9]{3}))*(\\,[0-9]+)?$"),
+        regex: new RegExp("^([\+\-\−])?[1-9]{1}[0-9]{0,2}(['΄’]([0-9]{3}))*(\\,[0-9]+)?$"),
         localeConfiguration: {
           thousands: "['΄’]",
           decimal: '\\,',
@@ -368,7 +368,7 @@ describe('Testing `cleanNumber` function', () => {
       },
       {
         numberRepresentation: "20'000,5",
-        regex: new RegExp("^([+|-])?[1-9]{1}[0-9]{0,2}(['΄’]([0-9]{3}))*(\\,[0-9]+)?$"),
+        regex: new RegExp("^([\+\-\−])?[1-9]{1}[0-9]{0,2}(['΄’]([0-9]{3}))*(\\,[0-9]+)?$"),
         localeConfiguration: {
           thousands: "['΄’]",
           decimal: '\\,',
@@ -377,7 +377,7 @@ describe('Testing `cleanNumber` function', () => {
       },
       {
         numberRepresentation: "20'000,567",
-        regex: new RegExp("^([+|-])?[1-9]{1}[0-9]{0,2}(['΄’]([0-9]{3}))*(\\,[0-9]+)?$"),
+        regex: new RegExp("^([\+\-\−])?[1-9]{1}[0-9]{0,2}(['΄’]([0-9]{3}))*(\\,[0-9]+)?$"),
         localeConfiguration: {
           thousands: "['΄’]",
           decimal: '\\,',
@@ -386,7 +386,7 @@ describe('Testing `cleanNumber` function', () => {
       },
       {
         numberRepresentation: '200,5',
-        regex: new RegExp("^([+|-])?[1-9]{1}[0-9]{0,2}(['΄’]([0-9]{3}))*(\\,[0-9]+)?$"),
+        regex: new RegExp("^([\+\-\−])?[1-9]{1}[0-9]{0,2}(['΄’]([0-9]{3}))*(\\,[0-9]+)?$"),
         localeConfiguration: {
           thousands: "['΄’]",
           decimal: '\\,',
@@ -395,7 +395,7 @@ describe('Testing `cleanNumber` function', () => {
       },
       {
         numberRepresentation: "1'200,00",
-        regex: new RegExp("^([+|-])?[1-9]{1}[0-9]{0,2}(['΄’]([0-9]{3}))*(\\,[0-9]+)?$"),
+        regex: new RegExp("^([\+\-\−])?[1-9]{1}[0-9]{0,2}(['΄’]([0-9]{3}))*(\\,[0-9]+)?$"),
         localeConfiguration: {
           thousands: "['΄’]",
           decimal: '\\,',
@@ -404,7 +404,7 @@ describe('Testing `cleanNumber` function', () => {
       },
       {
         numberRepresentation: '50',
-        regex: new RegExp("^([+|-])?[1-9]{1}[0-9]{0,2}(['΄’]([0-9]{3}))*(\\,[0-9]+)?$"),
+        regex: new RegExp("^([\+\-\−])?[1-9]{1}[0-9]{0,2}(['΄’]([0-9]{3}))*(\\,[0-9]+)?$"),
         localeConfiguration: {
           thousands: "['΄’]",
           decimal: '\\,',
@@ -426,7 +426,7 @@ describe('Testing `cleanNumber` function', () => {
     const testCases = [
       {
         numberRepresentation: '20.000',
-        regex: new RegExp('^[+|-]?(([1-9]{1}[0-9]{0,1}\\.)+([0-9]{2}\\.)*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\,[0-9]+)?$'),
+        regex: new RegExp('^[\+\-\−]?(([1-9]{1}[0-9]{0,1}\\.)+([0-9]{2}\\.)*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\,[0-9]+)?$'),
         localeConfiguration: {
           thousands: '\\.',
           decimal: '\\,',
@@ -435,7 +435,7 @@ describe('Testing `cleanNumber` function', () => {
       },
       {
         numberRepresentation: '20.000,5',
-        regex: new RegExp('^[+|-]?(([1-9]{1}[0-9]{0,1}\\.)+([0-9]{2}\\.)*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\,[0-9]+)?$'),
+        regex: new RegExp('^[\+\-\−]?(([1-9]{1}[0-9]{0,1}\\.)+([0-9]{2}\\.)*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\,[0-9]+)?$'),
         localeConfiguration: {
           thousands: '\\.',
           decimal: '\\,',
@@ -444,7 +444,7 @@ describe('Testing `cleanNumber` function', () => {
       },
       {
         numberRepresentation: '20.000,567',
-        regex: new RegExp('^[+|-]?(([1-9]{1}[0-9]{0,1}\\.)+([0-9]{2}\\.)*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\,[0-9]+)?$'),
+        regex: new RegExp('^[\+\-\−]?(([1-9]{1}[0-9]{0,1}\\.)+([0-9]{2}\\.)*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\,[0-9]+)?$'),
         localeConfiguration: {
           thousands: '\\.',
           decimal: '\\,',
@@ -453,7 +453,7 @@ describe('Testing `cleanNumber` function', () => {
       },
       {
         numberRepresentation: '200,5',
-        regex: new RegExp('^[+|-]?(([1-9]{1}[0-9]{0,1}\\.)+([0-9]{2}\\.)*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\,[0-9]+)?$'),
+        regex: new RegExp('^[\+\-\−]?(([1-9]{1}[0-9]{0,1}\\.)+([0-9]{2}\\.)*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\,[0-9]+)?$'),
         localeConfiguration: {
           thousands: '\\.',
           decimal: '\\,',
@@ -462,7 +462,7 @@ describe('Testing `cleanNumber` function', () => {
       },
       {
         numberRepresentation: '1.200,00',
-        regex: new RegExp('^[+|-]?(([1-9]{1}[0-9]{0,1}\\.)+([0-9]{2}\\.)*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\,[0-9]+)?$'),
+        regex: new RegExp('^[\+\-\−]?(([1-9]{1}[0-9]{0,1}\\.)+([0-9]{2}\\.)*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\,[0-9]+)?$'),
         localeConfiguration: {
           thousands: '\\.',
           decimal: '\\,',
@@ -471,7 +471,7 @@ describe('Testing `cleanNumber` function', () => {
       },
       {
         numberRepresentation: '50',
-        regex: new RegExp('^[+|-]?(([1-9]{1}[0-9]{0,1}\\.)+([0-9]{2}\\.)*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\,[0-9]+)?$'),
+        regex: new RegExp('^[\+\-\−]?(([1-9]{1}[0-9]{0,1}\\.)+([0-9]{2}\\.)*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\,[0-9]+)?$'),
         localeConfiguration: {
           thousands: '\\.',
           decimal: '\\,',
@@ -480,7 +480,7 @@ describe('Testing `cleanNumber` function', () => {
       },
       {
         numberRepresentation: '20,000',
-        regex: new RegExp('^[+|-]?(([1-9]{1}[0-9]{0,1}\\,)+([0-9]{2}\\,)*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\.[0-9]+)?$'),
+        regex: new RegExp('^[\+\-\−]?(([1-9]{1}[0-9]{0,1}\\,)+([0-9]{2}\\,)*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\.[0-9]+)?$'),
         localeConfiguration: {
           thousands: '\\,',
           decimal: '\\.',
@@ -489,7 +489,7 @@ describe('Testing `cleanNumber` function', () => {
       },
       {
         numberRepresentation: '20,000.5',
-        regex: new RegExp('^[+|-]?(([1-9]{1}[0-9]{0,1}\\,)+([0-9]{2}\\,)*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\.[0-9]+)?$'),
+        regex: new RegExp('^[\+\-\−]?(([1-9]{1}[0-9]{0,1}\\,)+([0-9]{2}\\,)*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\.[0-9]+)?$'),
         localeConfiguration: {
           thousands: '\\,',
           decimal: '\\.',
@@ -498,7 +498,7 @@ describe('Testing `cleanNumber` function', () => {
       },
       {
         numberRepresentation: '20,000.567',
-        regex: new RegExp('^[+|-]?(([1-9]{1}[0-9]{0,1}\\,)+([0-9]{2}\\,)*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\.[0-9]+)?$'),
+        regex: new RegExp('^[\+\-\−]?(([1-9]{1}[0-9]{0,1}\\,)+([0-9]{2}\\,)*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\.[0-9]+)?$'),
         localeConfiguration: {
           thousands: '\\,',
           decimal: '\\.',
@@ -507,7 +507,7 @@ describe('Testing `cleanNumber` function', () => {
       },
       {
         numberRepresentation: '200.5',
-        regex: new RegExp('^[+|-]?(([1-9]{1}[0-9]{0,1}\\,)+([0-9]{2}\\,)*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\.[0-9]+)?$'),
+        regex: new RegExp('^[\+\-\−]?(([1-9]{1}[0-9]{0,1}\\,)+([0-9]{2}\\,)*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\.[0-9]+)?$'),
         localeConfiguration: {
           thousands: '\\,',
           decimal: '\\.',
@@ -516,7 +516,7 @@ describe('Testing `cleanNumber` function', () => {
       },
       {
         numberRepresentation: '1,200.00',
-        regex: new RegExp('^[+|-]?(([1-9]{1}[0-9]{0,1}\\,)+([0-9]{2}\\,)*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\.[0-9]+)?$'),
+        regex: new RegExp('^[\+\-\−]?(([1-9]{1}[0-9]{0,1}\\,)+([0-9]{2}\\,)*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\.[0-9]+)?$'),
         localeConfiguration: {
           thousands: '\\,',
           decimal: '\\.',
@@ -525,7 +525,7 @@ describe('Testing `cleanNumber` function', () => {
       },
       {
         numberRepresentation: '50',
-        regex: new RegExp('^[+|-]?(([1-9]{1}[0-9]{0,1}\\,)+([0-9]{2}\\,)*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\.[0-9]+)?$'),
+        regex: new RegExp('^[\+\-\−]?(([1-9]{1}[0-9]{0,1}\\,)+([0-9]{2}\\,)*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\.[0-9]+)?$'),
         localeConfiguration: {
           thousands: '\\,',
           decimal: '\\.',
@@ -535,7 +535,7 @@ describe('Testing `cleanNumber` function', () => {
       {
         numberRepresentation: '20 000',
         regex: new RegExp(
-          '^[+|-]?(([1-9]{1}[0-9]{0,1}[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s])+([0-9]{2}[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s])*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\.[0-9]+)?$'
+          '^[\+\-\−]?(([1-9]{1}[0-9]{0,1}[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s])+([0-9]{2}[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s])*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\.[0-9]+)?$'
         ),
 
         localeConfiguration: {
@@ -547,7 +547,7 @@ describe('Testing `cleanNumber` function', () => {
       {
         numberRepresentation: '20 000.5',
         regex: new RegExp(
-          '^[+|-]?(([1-9]{1}[0-9]{0,1}[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s])+([0-9]{2}[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s])*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\.[0-9]+)?$'
+          '^[\+\-\−]?(([1-9]{1}[0-9]{0,1}[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s])+([0-9]{2}[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s])*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\.[0-9]+)?$'
         ),
 
         localeConfiguration: {
@@ -559,7 +559,7 @@ describe('Testing `cleanNumber` function', () => {
       {
         numberRepresentation: '20 000.567',
         regex: new RegExp(
-          '^[+|-]?(([1-9]{1}[0-9]{0,1}[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s])+([0-9]{2}[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s])*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\.[0-9]+)?$'
+          '^[\+\-\−]?(([1-9]{1}[0-9]{0,1}[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s])+([0-9]{2}[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s])*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\.[0-9]+)?$'
         ),
 
         localeConfiguration: {
@@ -571,7 +571,7 @@ describe('Testing `cleanNumber` function', () => {
       {
         numberRepresentation: '200.5',
         regex: new RegExp(
-          '^[+|-]?(([1-9]{1}[0-9]{0,1}[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s])+([0-9]{2}[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s])*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\.[0-9]+)?$'
+          '^[\+\-\−]?(([1-9]{1}[0-9]{0,1}[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s])+([0-9]{2}[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s])*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\.[0-9]+)?$'
         ),
 
         localeConfiguration: {
@@ -583,7 +583,7 @@ describe('Testing `cleanNumber` function', () => {
       {
         numberRepresentation: '1 200.00',
         regex: new RegExp(
-          '^[+|-]?(([1-9]{1}[0-9]{0,1}[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s])+([0-9]{2}[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s])*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\.[0-9]+)?$'
+          '^[\+\-\−]?(([1-9]{1}[0-9]{0,1}[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s])+([0-9]{2}[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s])*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\.[0-9]+)?$'
         ),
 
         localeConfiguration: {
@@ -595,7 +595,7 @@ describe('Testing `cleanNumber` function', () => {
       {
         numberRepresentation: '50',
         regex: new RegExp(
-          '^[+|-]?(([1-9]{1}[0-9]{0,1}[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s])+([0-9]{2}[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s])*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\.[0-9]+)?$'
+          '^[\+\-\−]?(([1-9]{1}[0-9]{0,1}[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s])+([0-9]{2}[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s])*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\.[0-9]+)?$'
         ),
 
         localeConfiguration: {
@@ -607,7 +607,7 @@ describe('Testing `cleanNumber` function', () => {
       {
         numberRepresentation: '20 000',
         regex: new RegExp(
-          '^[+|-]?(([1-9]{1}[0-9]{0,1}[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s])+([0-9]{2}[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s])*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\,[0-9]+)?$'
+          '^[\+\-\−]?(([1-9]{1}[0-9]{0,1}[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s])+([0-9]{2}[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s])*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\,[0-9]+)?$'
         ),
 
         localeConfiguration: {
@@ -619,7 +619,7 @@ describe('Testing `cleanNumber` function', () => {
       {
         numberRepresentation: '20 000,5',
         regex: new RegExp(
-          '^[+|-]?(([1-9]{1}[0-9]{0,1}[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s])+([0-9]{2}[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s])*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\,[0-9]+)?$'
+          '^[\+\-\−]?(([1-9]{1}[0-9]{0,1}[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s])+([0-9]{2}[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s])*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\,[0-9]+)?$'
         ),
 
         localeConfiguration: {
@@ -631,7 +631,7 @@ describe('Testing `cleanNumber` function', () => {
       {
         numberRepresentation: '20 000,567',
         regex: new RegExp(
-          '^[+|-]?(([1-9]{1}[0-9]{0,1}[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s])+([0-9]{2}[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s])*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\,[0-9]+)?$'
+          '^[\+\-\−]?(([1-9]{1}[0-9]{0,1}[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s])+([0-9]{2}[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s])*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\,[0-9]+)?$'
         ),
 
         localeConfiguration: {
@@ -643,7 +643,7 @@ describe('Testing `cleanNumber` function', () => {
       {
         numberRepresentation: '200,5',
         regex: new RegExp(
-          '^[+|-]?(([1-9]{1}[0-9]{0,1}[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s])+([0-9]{2}[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s])*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\,[0-9]+)?$'
+          '^[\+\-\−]?(([1-9]{1}[0-9]{0,1}[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s])+([0-9]{2}[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s])*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\,[0-9]+)?$'
         ),
 
         localeConfiguration: {
@@ -655,7 +655,7 @@ describe('Testing `cleanNumber` function', () => {
       {
         numberRepresentation: '1 200,00',
         regex: new RegExp(
-          '^[+|-]?(([1-9]{1}[0-9]{0,1}[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s])+([0-9]{2}[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s])*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\,[0-9]+)?$'
+          '^[\+\-\−]?(([1-9]{1}[0-9]{0,1}[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s])+([0-9]{2}[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s])*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\,[0-9]+)?$'
         ),
 
         localeConfiguration: {
@@ -667,7 +667,7 @@ describe('Testing `cleanNumber` function', () => {
       {
         numberRepresentation: '50',
         regex: new RegExp(
-          '^[+|-]?(([1-9]{1}[0-9]{0,1}[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s])+([0-9]{2}[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s])*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\,[0-9]+)?$'
+          '^[\+\-\−]?(([1-9]{1}[0-9]{0,1}[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s])+([0-9]{2}[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s])*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\,[0-9]+)?$'
         ),
 
         localeConfiguration: {
@@ -678,7 +678,7 @@ describe('Testing `cleanNumber` function', () => {
       },
       {
         numberRepresentation: "20'000",
-        regex: new RegExp(`^[+|-]?(([1-9]{1}[0-9]{0,1}['΄’])+([0-9]{2}['΄’])*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\.[0-9]+)?$`),
+        regex: new RegExp(`^[\+\-\−]?(([1-9]{1}[0-9]{0,1}['΄’])+([0-9]{2}['΄’])*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\.[0-9]+)?$`),
 
         localeConfiguration: {
           thousands: "['΄’]",
@@ -688,7 +688,7 @@ describe('Testing `cleanNumber` function', () => {
       },
       {
         numberRepresentation: "20'000.5",
-        regex: new RegExp(`^[+|-]?(([1-9]{1}[0-9]{0,1}['΄’])+([0-9]{2}['΄’])*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\.[0-9]+)?$`),
+        regex: new RegExp(`^[\+\-\−]?(([1-9]{1}[0-9]{0,1}['΄’])+([0-9]{2}['΄’])*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\.[0-9]+)?$`),
         localeConfiguration: {
           thousands: "['΄’]",
           decimal: '\\.',
@@ -697,7 +697,7 @@ describe('Testing `cleanNumber` function', () => {
       },
       {
         numberRepresentation: "20'000.567",
-        regex: new RegExp(`^[+|-]?(([1-9]{1}[0-9]{0,1}['΄’])+([0-9]{2}['΄’])*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\.[0-9]+)?$`),
+        regex: new RegExp(`^[\+\-\−]?(([1-9]{1}[0-9]{0,1}['΄’])+([0-9]{2}['΄’])*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\.[0-9]+)?$`),
         localeConfiguration: {
           thousands: "['΄’]",
           decimal: '\\.',
@@ -706,7 +706,7 @@ describe('Testing `cleanNumber` function', () => {
       },
       {
         numberRepresentation: '200.5',
-        regex: new RegExp(`^[+|-]?(([1-9]{1}[0-9]{0,1}['΄’])+([0-9]{2}['΄’])*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\.[0-9]+)?$`),
+        regex: new RegExp(`^[\+\-\−]?(([1-9]{1}[0-9]{0,1}['΄’])+([0-9]{2}['΄’])*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\.[0-9]+)?$`),
         localeConfiguration: {
           thousands: "['΄’]",
           decimal: '\\.',
@@ -715,7 +715,7 @@ describe('Testing `cleanNumber` function', () => {
       },
       {
         numberRepresentation: "1'200.00",
-        regex: new RegExp(`^[+|-]?(([1-9]{1}[0-9]{0,1}['΄’])+([0-9]{2}['΄’])*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\.[0-9]+)?$`),
+        regex: new RegExp(`^[\+\-\−]?(([1-9]{1}[0-9]{0,1}['΄’])+([0-9]{2}['΄’])*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\.[0-9]+)?$`),
         localeConfiguration: {
           thousands: "['΄’]",
           decimal: '\\.',
@@ -724,7 +724,7 @@ describe('Testing `cleanNumber` function', () => {
       },
       {
         numberRepresentation: '50',
-        regex: new RegExp(`^[+|-]?(([1-9]{1}[0-9]{0,1}['΄’])+([0-9]{2}['΄’])*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\.[0-9]+)?$`),
+        regex: new RegExp(`^[\+\-\−]?(([1-9]{1}[0-9]{0,1}['΄’])+([0-9]{2}['΄’])*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\.[0-9]+)?$`),
         localeConfiguration: {
           thousands: "['΄’]",
           decimal: '\\.',
@@ -733,7 +733,7 @@ describe('Testing `cleanNumber` function', () => {
       },
       {
         numberRepresentation: "20'000",
-        regex: new RegExp(`^[+|-]?(([1-9]{1}[0-9]{0,1}['΄’])+([0-9]{2}['΄’])*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\,[0-9]+)?$`),
+        regex: new RegExp(`^[\+\-\−]?(([1-9]{1}[0-9]{0,1}['΄’])+([0-9]{2}['΄’])*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\,[0-9]+)?$`),
         localeConfiguration: {
           thousands: "['΄’]",
           decimal: '\\,',
@@ -742,7 +742,7 @@ describe('Testing `cleanNumber` function', () => {
       },
       {
         numberRepresentation: "20'000,5",
-        regex: new RegExp(`^[+|-]?(([1-9]{1}[0-9]{0,1}['΄’])+([0-9]{2}['΄’])*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\,[0-9]+)?$`),
+        regex: new RegExp(`^[\+\-\−]?(([1-9]{1}[0-9]{0,1}['΄’])+([0-9]{2}['΄’])*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\,[0-9]+)?$`),
         localeConfiguration: {
           thousands: "['΄’]",
           decimal: '\\,',
@@ -751,7 +751,7 @@ describe('Testing `cleanNumber` function', () => {
       },
       {
         numberRepresentation: "20'000,567",
-        regex: new RegExp(`^[+|-]?(([1-9]{1}[0-9]{0,1}['΄’])+([0-9]{2}['΄’])*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\,[0-9]+)?$`),
+        regex: new RegExp(`^[\+\-\−]?(([1-9]{1}[0-9]{0,1}['΄’])+([0-9]{2}['΄’])*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\,[0-9]+)?$`),
         localeConfiguration: {
           thousands: "['΄’]",
           decimal: '\\,',
@@ -760,7 +760,7 @@ describe('Testing `cleanNumber` function', () => {
       },
       {
         numberRepresentation: '200,5',
-        regex: new RegExp(`^[+|-]?(([1-9]{1}[0-9]{0,1}['΄’])+([0-9]{2}['΄’])*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\,[0-9]+)?$`),
+        regex: new RegExp(`^[\+\-\−]?(([1-9]{1}[0-9]{0,1}['΄’])+([0-9]{2}['΄’])*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\,[0-9]+)?$`),
         localeConfiguration: {
           thousands: "['΄’]",
           decimal: '\\,',
@@ -769,7 +769,7 @@ describe('Testing `cleanNumber` function', () => {
       },
       {
         numberRepresentation: "1'200,00",
-        regex: new RegExp(`^[+|-]?(([1-9]{1}[0-9]{0,1}['΄’])+([0-9]{2}['΄’])*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\,[0-9]+)?$`),
+        regex: new RegExp(`^[\+\-\−]?(([1-9]{1}[0-9]{0,1}['΄’])+([0-9]{2}['΄’])*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\,[0-9]+)?$`),
         localeConfiguration: {
           thousands: "['΄’]",
           decimal: '\\,',
@@ -778,7 +778,7 @@ describe('Testing `cleanNumber` function', () => {
       },
       {
         numberRepresentation: '50',
-        regex: new RegExp(`^[+|-]?(([1-9]{1}[0-9]{0,1}['΄’])+([0-9]{2}['΄’])*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\,[0-9]+)?$`),
+        regex: new RegExp(`^[\+\-\−]?(([1-9]{1}[0-9]{0,1}['΄’])+([0-9]{2}['΄’])*[0-9]{3}|[1-9]{1}[0-9]{0,2}|0)(\\,[0-9]+)?$`),
         localeConfiguration: {
           thousands: "['΄’]",
           decimal: '\\,',
@@ -799,7 +799,7 @@ describe('Testing `cleanNumber` function', () => {
     const testCases = [
       {
         numberRepresentation: '50,000.12',
-        regex: new RegExp('^([+|-])?[1-9]{1}[0-9]{0,2}(\\.([0-9]{3}))*(\\,[0-9]+)?$'),
+        regex: new RegExp('^([\+\-\−])?[1-9]{1}[0-9]{0,2}(\\.([0-9]{3}))*(\\,[0-9]+)?$'),
         localeConfiguration: {
           thousands: '\\.',
           decimal: '\\,',
@@ -808,7 +808,7 @@ describe('Testing `cleanNumber` function', () => {
       {
         numberRepresentation: '50,000.12',
         regex: new RegExp(
-          '^([+|-])?[1-9]{1}[0-9]{0,2}([\\u202F\\u00A0\\u2000\\u2001\\u2003\\s]([0-9]{3}))*(\\.[0-9]+)?$'
+          '^([\+\-\−])?[1-9]{1}[0-9]{0,2}([\\u202F\\u00A0\\u2000\\u2001\\u2003\\s]([0-9]{3}))*(\\.[0-9]+)?$'
         ),
         localeConfiguration: {
           thousands: '[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s]',
@@ -818,7 +818,7 @@ describe('Testing `cleanNumber` function', () => {
       {
         numberRepresentation: '50.000,12',
         regex: new RegExp(
-          '^([+|-])?[1-9]{1}[0-9]{0,2}([\\u202F\\u00A0\\u2000\\u2001\\u2003\\s]([0-9]{3}))*(\\,[0-9]+)?$'
+          '^([\+\-\−])?[1-9]{1}[0-9]{0,2}([\\u202F\\u00A0\\u2000\\u2001\\u2003\\s]([0-9]{3}))*(\\,[0-9]+)?$'
         ),
         localeConfiguration: {
           thousands: '[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s]',
@@ -827,7 +827,7 @@ describe('Testing `cleanNumber` function', () => {
       },
       {
         numberRepresentation: '50.000,12',
-        regex: new RegExp("^([+|-])?[1-9]{1}[0-9]{0,2}(['΄’]([0-9]{3}))*(\\,[0-9]+)?$"),
+        regex: new RegExp("^([\+\-\−])?[1-9]{1}[0-9]{0,2}(['΄’]([0-9]{3}))*(\\,[0-9]+)?$"),
         localeConfiguration: {
           thousands: "['΄’]",
           decimal: '\\,',
@@ -835,7 +835,7 @@ describe('Testing `cleanNumber` function', () => {
       },
       {
         numberRepresentation: '50.000,12',
-        regex: new RegExp("^([+|-])?[1-9]{1}[0-9]{0,2}(['΄’]([0-9]{3}))*(\\.[0-9]+)?$"),
+        regex: new RegExp("^([\+\-\−])?[1-9]{1}[0-9]{0,2}(['΄’]([0-9]{3}))*(\\.[0-9]+)?$"),
         localeConfiguration: {
           thousands: "['΄’]",
           decimal: '\\.',

--- a/src/get-number/specs/get-number.no-no.spec.js
+++ b/src/get-number/specs/get-number.no-no.spec.js
@@ -1,0 +1,403 @@
+const getNumber = require('../get-number');
+const { testCaseGenerator, supportedNumberOfFractionDigits } = require('./test-case-generator');
+
+beforeEach(() => {
+  // Making sure the `console.error` implementation is empty
+  // in order to avoid tests failing when a warning is logged.
+  jest.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+describe('Testing `getNumber` with `no-NO` locale on positive numbers', () => {
+  test(`(Manually) It should return a positive decimal literal when given an 
+  implicitly positive string representation`, () => {
+    expect(getNumber('0,0', 'no-NO')).toBeCloseTo(0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('0,45', 'no-NO')).toBeCloseTo(0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('0,3', 'no-NO')).toBeCloseTo(0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('0,243225', 'no-NO')).toBeCloseTo(0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('200', 'no-NO')).toBeCloseTo(200, supportedNumberOfFractionDigits);
+    expect(getNumber('200,45', 'no-NO')).toBeCloseTo(200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('873,00', 'no-NO')).toBeCloseTo(873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('2 050', 'no-NO')).toBeCloseTo(2050, supportedNumberOfFractionDigits);
+    expect(getNumber('2050', 'no-NO')).toBeCloseTo(2050, supportedNumberOfFractionDigits);
+    expect(getNumber('2 000,30', 'no-NO')).toBeCloseTo(2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('2000,30', 'no-NO')).toBeCloseTo(2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('2 342,0', 'no-NO')).toBeCloseTo(2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('2342,0', 'no-NO')).toBeCloseTo(2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('20 000', 'no-NO')).toBeCloseTo(20000, supportedNumberOfFractionDigits);
+    expect(getNumber('20000', 'no-NO')).toBeCloseTo(20000, supportedNumberOfFractionDigits);
+    expect(getNumber('20000,34', 'no-NO')).toBeCloseTo(20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('20000,34', 'no-NO')).toBeCloseTo(20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('200 000', 'no-NO')).toBeCloseTo(200000, supportedNumberOfFractionDigits);
+    expect(getNumber('200000', 'no-NO')).toBeCloseTo(200000, supportedNumberOfFractionDigits);
+    expect(getNumber('2 000 000', 'no-NO')).toBeCloseTo(2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('2000000', 'no-NO')).toBeCloseTo(2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('12 054 100,55', 'no-NO')).toBeCloseTo(12054100.55, supportedNumberOfFractionDigits);
+    expect(getNumber('12054100,55', 'no-NO')).toBeCloseTo(12054100.55, supportedNumberOfFractionDigits);
+  });
+
+  test(`(Manually) It should return a positive decimal literal when given an 
+  explicitly positive string representation`, () => {
+    expect(getNumber('+0,0', 'no-NO')).toBeCloseTo(0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+0,45', 'no-NO')).toBeCloseTo(0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('+0,3', 'no-NO')).toBeCloseTo(0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('+0,243225', 'no-NO')).toBeCloseTo(0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('+200', 'no-NO')).toBeCloseTo(200, supportedNumberOfFractionDigits);
+    expect(getNumber('+200,45', 'no-NO')).toBeCloseTo(200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('+873,00', 'no-NO')).toBeCloseTo(873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+2 050', 'no-NO')).toBeCloseTo(2050, supportedNumberOfFractionDigits);
+    expect(getNumber('+2050', 'no-NO')).toBeCloseTo(2050, supportedNumberOfFractionDigits);
+    expect(getNumber('+2 000,30', 'no-NO')).toBeCloseTo(2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('+2000,30', 'no-NO')).toBeCloseTo(2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('+2 342,0', 'no-NO')).toBeCloseTo(2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+2342,0', 'no-NO')).toBeCloseTo(2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+20 000', 'no-NO')).toBeCloseTo(20000, supportedNumberOfFractionDigits);
+    expect(getNumber('+20000', 'no-NO')).toBeCloseTo(20000, supportedNumberOfFractionDigits);
+    expect(getNumber('+20 000,34', 'no-NO')).toBeCloseTo(20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('+20000,34', 'no-NO')).toBeCloseTo(20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('+200 000', 'no-NO')).toBeCloseTo(200000, supportedNumberOfFractionDigits);
+    expect(getNumber('+200000', 'no-NO')).toBeCloseTo(200000, supportedNumberOfFractionDigits);
+    expect(getNumber('+2 000 000', 'no-NO')).toBeCloseTo(2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('+2000000', 'no-NO')).toBeCloseTo(2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('+12 054 100,55', 'no-NO')).toBeCloseTo(12054100.55, supportedNumberOfFractionDigits);
+    expect(getNumber('+12054100,55', 'no-NO')).toBeCloseTo(12054100.55, supportedNumberOfFractionDigits);
+  });
+
+  test(`(Automatically)(Range: [0, 1]) It should return a possible decimal literal when given an
+  implicitly positive string representation`, () => {
+    const testCases = testCaseGenerator('no-NO', 0, 0, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'no-NO')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [1, 100]) It should return a possible decimal literal when given an
+  implicitly positive string representation`, () => {
+    const testCases = testCaseGenerator('no-NO', 1, 100, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'no-NO')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [100, 1.000]) It should return a possible decimal literal when given an
+  implicitly positive string representation`, () => {
+    const testCases = testCaseGenerator('no-NO', 100, 1000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'no-NO')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [1.000, 10.000]) It should return a possible decimal literal when given an
+  implicitly positive string representation`, () => {
+    const testCases = testCaseGenerator('no-NO', 1000, 10000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'no-NO')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [10.000, 100.000]) It should return a possible decimal literal when given an
+  implicitly positive string representation`, () => {
+    const testCases = testCaseGenerator('no-NO', 10000, 100000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'no-NO')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [100.000, 1.000.000]) It should return a possible decimal literal when given an
+  implicitly positive string representation`, () => {
+    const testCases = testCaseGenerator('no-NO', 100000, 1000000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'no-NO')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [1.000.000, 10.000.000]) It should return a possible decimal literal when given an
+  implicitly positive string representation`, () => {
+    const testCases = testCaseGenerator('no-NO', 1000000, 10000000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'no-NO')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [10.000.000, 100.000.000]) It should return a possible decimal literal when given an
+  implicitly positive string representation`, () => {
+    const testCases = testCaseGenerator('no-NO', 10000000, 100000000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'no-NO')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [100.000.000, 1.000.000.000]) It should return a possible decimal literal when given an
+  implicitly positive string representation`, () => {
+    const testCases = testCaseGenerator('no-NO', 100000000, 1000000000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'no-NO')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [1.000.000.000, 10.000.000.000]) It should return a possible decimal literal when given an
+  implicitly positive string representation`, () => {
+    const testCases = testCaseGenerator('no-NO', 1000000000, 10000000000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'no-NO')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [10.000.000.000, 100.000.000.000]) It should return a possible decimal literal when given an
+  implicitly positive string representation`, () => {
+    const testCases = testCaseGenerator('no-NO', 10000000000, 100000000000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'no-NO')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [100.000.000.000, 1.000.000.000.000]) It should return a possible decimal literal when given an
+  implicitly positive string representation`, () => {
+    const testCases = testCaseGenerator('no-NO', 100000000000, 1000000000000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'no-NO')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [1.000.000.000.000, 10.000.000.000.000]) It should return a possible decimal literal when given an
+  implicitly positive string representation`, () => {
+    const testCases = testCaseGenerator('no-NO', 1000000000000, 10000000000000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'no-NO')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [10.000.000.000.000, 100.000.000.000.000]) It should return a possible decimal literal when given an
+  implicitly positive string representation`, () => {
+    const testCases = testCaseGenerator('no-NO', 10000000000000, 100000000000000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'no-NO')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+});
+
+describe('Testing `getNumber` with `no-NO` locale on negative numbers', () => {
+  test(`(Manually) It should return a negative decimal literal when given a
+  negative string representation`, () => {
+    expect(getNumber('-0,0', 'no-NO')).toBeCloseTo(-0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-0,45', 'no-NO')).toBeCloseTo(-0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('-0,3', 'no-NO')).toBeCloseTo(-0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('-0,243225', 'no-NO')).toBeCloseTo(-0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('-200', 'no-NO')).toBeCloseTo(-200, supportedNumberOfFractionDigits);
+    expect(getNumber('-200,45', 'no-NO')).toBeCloseTo(-200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('-873,00', 'no-NO')).toBeCloseTo(-873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-2 050', 'no-NO')).toBeCloseTo(-2050, supportedNumberOfFractionDigits);
+    expect(getNumber('-2050', 'no-NO')).toBeCloseTo(-2050, supportedNumberOfFractionDigits);
+    expect(getNumber('-2 000,30', 'no-NO')).toBeCloseTo(-2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('-2000,30', 'no-NO')).toBeCloseTo(-2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('-2 342,0', 'no-NO')).toBeCloseTo(-2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-2342,0', 'no-NO')).toBeCloseTo(-2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-20 000', 'no-NO')).toBeCloseTo(-20000, supportedNumberOfFractionDigits);
+    expect(getNumber('-20000', 'no-NO')).toBeCloseTo(-20000, supportedNumberOfFractionDigits);
+    expect(getNumber('-20 000,34', 'no-NO')).toBeCloseTo(-20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('-20000,34', 'no-NO')).toBeCloseTo(-20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('-200 000', 'no-NO')).toBeCloseTo(-200000, supportedNumberOfFractionDigits);
+    expect(getNumber('-200000', 'no-NO')).toBeCloseTo(-200000, supportedNumberOfFractionDigits);
+    expect(getNumber('-2 000 000', 'no-NO')).toBeCloseTo(-2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('-2000000', 'no-NO')).toBeCloseTo(-2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('-12 054 100,55', 'no-NO')).toBeCloseTo(-12054100.55, supportedNumberOfFractionDigits);
+    expect(getNumber('-12054100,55', 'no-NO')).toBeCloseTo(-12054100.55, supportedNumberOfFractionDigits);
+  });
+
+  test(`(Automatically)(Range: [-1, 0]) It should return a possible decimal literal when given an
+  negative string representation`, () => {
+    const testCases = testCaseGenerator('no-NO', 0, -2, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'no-NO')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [-100, -1]) It should return a possible decimal literal when given an
+  negative string representation`, () => {
+    const testCases = testCaseGenerator('no-NO', -100, -1, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'no-NO')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [-1.000, -100]) It should return a possible decimal literal when given an
+  negative string representation`, () => {
+    const testCases = testCaseGenerator('no-NO', -1000, -100, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'no-NO')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [-10.000, -1.000]) It should return a possible decimal literal when given an
+  negative string representation`, () => {
+    const testCases = testCaseGenerator('no-NO', -10000, -1000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'no-NO')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [-100.000, -10.000]) It should return a possible decimal literal when given an
+  negative string representation`, () => {
+    const testCases = testCaseGenerator('no-NO', -100000, -10000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'no-NO')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [-1.000.000, -100.000]) It should return a possible decimal literal when given an
+  negative string representation`, () => {
+    const testCases = testCaseGenerator('no-NO', -1000000, -100000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'no-NO')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [-10.000.000, -1.000.000]) It should return a possible decimal literal when given an
+  negative string representation`, () => {
+    const testCases = testCaseGenerator('no-NO', -10000000, -1000000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'no-NO')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [-100.000.000, -10.000.000]) It should return a possible decimal literal when given an
+  negative string representation`, () => {
+    const testCases = testCaseGenerator('no-NO', -100000000, -10000000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'no-NO')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [-1.000.000.000, -100.000.000]) It should return a possible decimal literal when given an
+  negative string representation`, () => {
+    const testCases = testCaseGenerator('no-NO', -1000000000, -100000000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'no-NO')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [-10.000.000.000, -1.000.000.000]) It should return a possible decimal literal when given an
+  negative string representation`, () => {
+    const testCases = testCaseGenerator('no-NO', -10000000000, -1000000000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'no-NO')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [-100.000.000.000, -10.000.000.000]) It should return a possible decimal literal when given an
+  negative string representation`, () => {
+    const testCases = testCaseGenerator('no-NO', -100000000000, -10000000000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'no-NO')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [-1.000.000.000.000, -100.000.000.000]) It should return a possible decimal literal when given an
+  negative string representation`, () => {
+    const testCases = testCaseGenerator('no-NO', -1000000000000, -100000000000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'no-NO')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [-10.000.000.000.000, -1.000.000.000.000]) It should return a possible decimal literal when given an
+  negative string representation`, () => {
+    const testCases = testCaseGenerator('no-NO', -10000000000000, -1000000000000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'no-NO')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+});
+
+describe('Testing `getNumber` with `no-NO` locale on invalid cases', () => {
+  test(`(Manually) It should return 'null' when locale is not supported`, () => {
+    expect(getNumber('120', 'unsupported-locale')).toBe(null);
+  });
+
+  test(`(Manually) It should return 'null' when the given number does not
+  match the given locale`, () => {
+    expect(getNumber('120,000.23', 'no-NO')).toBe(null);
+    expect(getNumber('12 000.23', 'no-NO')).toBe(null);
+    expect(getNumber("12'000,23", 'no-NO')).toBe(null);
+  });
+});

--- a/src/get-number/specs/get-number.no.spec.js
+++ b/src/get-number/specs/get-number.no.spec.js
@@ -1,0 +1,405 @@
+const getNumber = require('../get-number');
+const { testCaseGenerator, supportedNumberOfFractionDigits } = require('./test-case-generator');
+
+beforeEach(() => {
+  // Making sure the `console.error` implementation is empty
+  // in order to avoid tests failing when a warning is logged.
+  jest.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+describe('Testing `getNumber` with `no` locale on positive numbers', () => {
+  test(`(Manually) It should return a positive decimal literal when given an 
+  implicitly positive string representation`, () => {
+    expect(getNumber('0,0', 'no')).toBeCloseTo(0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('0,45', 'no')).toBeCloseTo(0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('0,3', 'no')).toBeCloseTo(0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('0,243225', 'no')).toBeCloseTo(0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('200', 'no')).toBeCloseTo(200, supportedNumberOfFractionDigits);
+    expect(getNumber('200,45', 'no')).toBeCloseTo(200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('873,00', 'no')).toBeCloseTo(873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('2 050', 'no')).toBeCloseTo(2050, supportedNumberOfFractionDigits);
+    expect(getNumber('2050', 'no')).toBeCloseTo(2050, supportedNumberOfFractionDigits);
+    expect(getNumber('2 000,30', 'no')).toBeCloseTo(2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('2000,30', 'no')).toBeCloseTo(2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('2 342,0', 'no')).toBeCloseTo(2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('2342,0', 'no')).toBeCloseTo(2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('20 000', 'no')).toBeCloseTo(20000, supportedNumberOfFractionDigits);
+    expect(getNumber('20000', 'no')).toBeCloseTo(20000, supportedNumberOfFractionDigits);
+    expect(getNumber('20000,34', 'no')).toBeCloseTo(20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('20000,34', 'no')).toBeCloseTo(20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('200 000', 'no')).toBeCloseTo(200000, supportedNumberOfFractionDigits);
+    expect(getNumber('200000', 'no')).toBeCloseTo(200000, supportedNumberOfFractionDigits);
+    expect(getNumber('2 000 000', 'no')).toBeCloseTo(2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('2000000', 'no')).toBeCloseTo(2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('12 054 100,55', 'no')).toBeCloseTo(12054100.55, supportedNumberOfFractionDigits);
+    expect(getNumber('12054100,55', 'no')).toBeCloseTo(12054100.55, supportedNumberOfFractionDigits);
+  });
+
+  test(`(Manually) It should return a positive decimal literal when given an 
+  explicitly positive string representation`, () => {
+    expect(getNumber('+0,0', 'no')).toBeCloseTo(0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+0,45', 'no')).toBeCloseTo(0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('+0,3', 'no')).toBeCloseTo(0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('+0,243225', 'no')).toBeCloseTo(0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('+200', 'no')).toBeCloseTo(200, supportedNumberOfFractionDigits);
+    expect(getNumber('+200,45', 'no')).toBeCloseTo(200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('+873,00', 'no')).toBeCloseTo(873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+2 050', 'no')).toBeCloseTo(2050, supportedNumberOfFractionDigits);
+    expect(getNumber('+2050', 'no')).toBeCloseTo(2050, supportedNumberOfFractionDigits);
+    expect(getNumber('+2 000,30', 'no')).toBeCloseTo(2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('+2000,30', 'no')).toBeCloseTo(2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('+2 342,0', 'no')).toBeCloseTo(2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+2342,0', 'no')).toBeCloseTo(2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+20 000', 'no')).toBeCloseTo(20000, supportedNumberOfFractionDigits);
+    expect(getNumber('+20000', 'no')).toBeCloseTo(20000, supportedNumberOfFractionDigits);
+    expect(getNumber('+20 000,34', 'no')).toBeCloseTo(20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('+20000,34', 'no')).toBeCloseTo(20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('+200 000', 'no')).toBeCloseTo(200000, supportedNumberOfFractionDigits);
+    expect(getNumber('+200000', 'no')).toBeCloseTo(200000, supportedNumberOfFractionDigits);
+    expect(getNumber('+2 000 000', 'no')).toBeCloseTo(2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('+2000000', 'no')).toBeCloseTo(2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('+12 054 100,55', 'no')).toBeCloseTo(12054100.55, supportedNumberOfFractionDigits);
+    expect(getNumber('+12054100,55', 'no')).toBeCloseTo(12054100.55, supportedNumberOfFractionDigits);
+  });
+
+  test(`(Automatically)(Range: [0, 1]) It should return a possible decimal literal when given an
+  implicitly positive string representation`, () => {
+    const testCases = testCaseGenerator('no', 0, 0, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'no')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [1, 100]) It should return a possible decimal literal when given an
+  implicitly positive string representation`, () => {
+    const testCases = testCaseGenerator('no', 1, 100, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'no')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [100, 1.000]) It should return a possible decimal literal when given an
+  implicitly positive string representation`, () => {
+    const testCases = testCaseGenerator('no', 100, 1000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'no')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [1.000, 10.000]) It should return a possible decimal literal when given an
+  implicitly positive string representation`, () => {
+    const testCases = testCaseGenerator('no', 1000, 10000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'no')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [10.000, 100.000]) It should return a possible decimal literal when given an
+  implicitly positive string representation`, () => {
+    const testCases = testCaseGenerator('no', 10000, 100000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'no')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [100.000, 1.000.000]) It should return a possible decimal literal when given an
+  implicitly positive string representation`, () => {
+    const testCases = testCaseGenerator('no', 100000, 1000000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'no')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [1.000.000, 10.000.000]) It should return a possible decimal literal when given an
+  implicitly positive string representation`, () => {
+    const testCases = testCaseGenerator('no', 1000000, 10000000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'no')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [10.000.000, 100.000.000]) It should return a possible decimal literal when given an
+  implicitly positive string representation`, () => {
+    const testCases = testCaseGenerator('no', 10000000, 100000000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'no')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [100.000.000, 1.000.000.000]) It should return a possible decimal literal when given an
+  implicitly positive string representation`, () => {
+    const testCases = testCaseGenerator('no', 100000000, 1000000000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'no')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [1.000.000.000, 10.000.000.000]) It should return a possible decimal literal when given an
+  implicitly positive string representation`, () => {
+    const testCases = testCaseGenerator('no', 1000000000, 10000000000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'no')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [10.000.000.000, 100.000.000.000]) It should return a possible decimal literal when given an
+  implicitly positive string representation`, () => {
+    const testCases = testCaseGenerator('no', 10000000000, 100000000000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'no')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [100.000.000.000, 1.000.000.000.000]) It should return a possible decimal literal when given an
+  implicitly positive string representation`, () => {
+    const testCases = testCaseGenerator('no', 100000000000, 1000000000000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'no')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [1.000.000.000.000, 10.000.000.000.000]) It should return a possible decimal literal when given an
+  implicitly positive string representation`, () => {
+    const testCases = testCaseGenerator('no', 1000000000000, 10000000000000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'no')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [10.000.000.000.000, 100.000.000.000.000]) It should return a possible decimal literal when given an
+  implicitly positive string representation`, () => {
+    const testCases = testCaseGenerator('no', 10000000000000, 100000000000000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'no')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+});
+
+describe('Testing `getNumber` with `no` locale on negative numbers', () => {
+  test(`(Manually) It should return a negative decimal literal when given a
+  negative string representation`, () => {
+    expect(getNumber('-0,0', 'no')).toBeCloseTo(-0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-0,45', 'no')).toBeCloseTo(-0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('-0,3', 'no')).toBeCloseTo(-0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('-0,243225', 'no')).toBeCloseTo(-0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('-200', 'no')).toBeCloseTo(-200, supportedNumberOfFractionDigits);
+    expect(getNumber('-200,45', 'no')).toBeCloseTo(-200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('-873,00', 'no')).toBeCloseTo(-873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-2 050', 'no')).toBeCloseTo(-2050, supportedNumberOfFractionDigits);
+    expect(getNumber('-2050', 'no')).toBeCloseTo(-2050, supportedNumberOfFractionDigits);
+    expect(getNumber('-2 000,30', 'no')).toBeCloseTo(-2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('-2000,30', 'no')).toBeCloseTo(-2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('-2 342,0', 'no')).toBeCloseTo(-2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-2342,0', 'no')).toBeCloseTo(-2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-20 000', 'no')).toBeCloseTo(-20000, supportedNumberOfFractionDigits);
+    expect(getNumber('-20000', 'no')).toBeCloseTo(-20000, supportedNumberOfFractionDigits);
+    expect(getNumber('-20 000,34', 'no')).toBeCloseTo(-20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('-20000,34', 'no')).toBeCloseTo(-20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('-200 000', 'no')).toBeCloseTo(-200000, supportedNumberOfFractionDigits);
+    expect(getNumber('-200000', 'no')).toBeCloseTo(-200000, supportedNumberOfFractionDigits);
+    expect(getNumber('-2 000 000', 'no')).toBeCloseTo(-2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('-2000000', 'no')).toBeCloseTo(-2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('-12 054 100,55', 'no')).toBeCloseTo(-12054100.55, supportedNumberOfFractionDigits);
+    expect(getNumber('-12054100,55', 'no')).toBeCloseTo(-12054100.55, supportedNumberOfFractionDigits);
+  });
+
+  test(`(Automatically)(Range: [-1, 0]) It should return a possible decimal literal when given an
+  negative string representation`, () => {
+    const testCases = testCaseGenerator('no', 0, -2, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'no')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [-100, -1]) It should return a possible decimal literal when given an
+  negative string representation`, () => {
+    const testCases = testCaseGenerator('no', -100, -1, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'no')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [-1.000, -100]) It should return a possible decimal literal when given an
+  negative string representation`, () => {
+    const testCases = testCaseGenerator('no', -1000, -100, 1000);
+
+    console.log(testCases);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'no')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [-10.000, -1.000]) It should return a possible decimal literal when given an
+  negative string representation`, () => {
+    const testCases = testCaseGenerator('no', -10000, -1000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'no')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [-100.000, -10.000]) It should return a possible decimal literal when given an
+  negative string representation`, () => {
+    const testCases = testCaseGenerator('no', -100000, -10000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'no')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [-1.000.000, -100.000]) It should return a possible decimal literal when given an
+  negative string representation`, () => {
+    const testCases = testCaseGenerator('no', -1000000, -100000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'no')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [-10.000.000, -1.000.000]) It should return a possible decimal literal when given an
+  negative string representation`, () => {
+    const testCases = testCaseGenerator('no', -10000000, -1000000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'no')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [-100.000.000, -10.000.000]) It should return a possible decimal literal when given an
+  negative string representation`, () => {
+    const testCases = testCaseGenerator('no', -100000000, -10000000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'no')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [-1.000.000.000, -100.000.000]) It should return a possible decimal literal when given an
+  negative string representation`, () => {
+    const testCases = testCaseGenerator('no', -1000000000, -100000000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'no')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [-10.000.000.000, -1.000.000.000]) It should return a possible decimal literal when given an
+  negative string representation`, () => {
+    const testCases = testCaseGenerator('no', -10000000000, -1000000000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'no')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [-100.000.000.000, -10.000.000.000]) It should return a possible decimal literal when given an
+  negative string representation`, () => {
+    const testCases = testCaseGenerator('no', -100000000000, -10000000000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'no')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [-1.000.000.000.000, -100.000.000.000]) It should return a possible decimal literal when given an
+  negative string representation`, () => {
+    const testCases = testCaseGenerator('no', -1000000000000, -100000000000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'no')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [-10.000.000.000.000, -1.000.000.000.000]) It should return a possible decimal literal when given an
+  negative string representation`, () => {
+    const testCases = testCaseGenerator('no', -10000000000000, -1000000000000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'no')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+});
+
+describe('Testing `getNumber` with `no` locale on invalid cases', () => {
+  test(`(Manually) It should return 'null' when locale is not supported`, () => {
+    expect(getNumber('120', 'unsupported-locale')).toBe(null);
+  });
+
+  test(`(Manually) It should return 'null' when the given number does not
+  match the given locale`, () => {
+    expect(getNumber('120,000.23', 'no')).toBe(null);
+    expect(getNumber('12 000.23', 'no')).toBe(null);
+    expect(getNumber("12'000,23", 'no')).toBe(null);
+  });
+});

--- a/src/get-number/specs/get-number.no.spec.js
+++ b/src/get-number/specs/get-number.no.spec.js
@@ -270,8 +270,6 @@ describe('Testing `getNumber` with `no` locale on negative numbers', () => {
   test(`(Automatically)(Range: [-1.000, -100]) It should return a possible decimal literal when given an
   negative string representation`, () => {
     const testCases = testCaseGenerator('no', -1000, -100, 1000);
-
-    console.log(testCases);
     testCases.forEach((testCase) => {
       expect(getNumber(testCase.stringRepresentation, 'no')).toBeCloseTo(
         testCase.groundTruth,

--- a/src/locale-mapper.js
+++ b/src/locale-mapper.js
@@ -168,6 +168,10 @@ const localeMapper = {
     thousands: '[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s]?',
     decimal: '\\,',
   },
+  'no-no': {
+    thousands: '[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s]?',
+    decimal: '\\,',
+  },
   'pt': {
     thousands: '\\.?',
     decimal: '\\,',

--- a/src/locale-mapper.js
+++ b/src/locale-mapper.js
@@ -164,6 +164,10 @@ const localeMapper = {
     thousands: '\\.?',
     decimal: '\\,',
   },
+  'no': {
+    thousands: '[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s]?',
+    decimal: '\\,',
+  },
   'pt': {
     thousands: '\\.?',
     decimal: '\\,',


### PR DESCRIPTION
# Description

Added full support for the no-* locale. Also, I patched an issue where the regex was not handling correctly the `plus` and `minus` signs. Finally, I added support for a new `minus` sign.

Fixes #23 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

I have tested the new locale following the instructions from the wiki page.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
