### PR TITLE
Wired `he` and `he-il` locales.

### DIFF
--- a/src/get-number/specs/get-number.he-il.spec.js
+++ b/src/get-number/specs/get-number.he-il.spec.js
@@ -1,0 +1,403 @@
+const getNumber = require('../get-number');
+const { testCaseGenerator, supportedNumberOfFractionDigits } = require('./test-case-generator');
+
+beforeEach(() => {
+  // Making sure the `console.error` implementation is empty
+  // in order to avoid tests failing when a warning is logged.
+  jest.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+describe('Testing `getNumber` with `he-il` locale on positive numbers', () => {
+  test(`(Manually) It should return a positive decimal literal when given an 
+  implicitly positive string representation`, () => {
+    expect(getNumber('0.0', 'he-il')).toBeCloseTo(0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('0.45', 'he-il')).toBeCloseTo(0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('0.3', 'he-il')).toBeCloseTo(0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('0.243225', 'he-il')).toBeCloseTo(0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('200', 'he-il')).toBeCloseTo(200, supportedNumberOfFractionDigits);
+    expect(getNumber('200.45', 'he-il')).toBeCloseTo(200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('873.00', 'he-il')).toBeCloseTo(873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('2,050', 'he-il')).toBeCloseTo(2050, supportedNumberOfFractionDigits);
+    expect(getNumber('2050', 'he-il')).toBeCloseTo(2050, supportedNumberOfFractionDigits);
+    expect(getNumber('2,000.30', 'he-il')).toBeCloseTo(2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('2000.30', 'he-il')).toBeCloseTo(2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('2,342.0', 'he-il')).toBeCloseTo(2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('2342.0', 'he-il')).toBeCloseTo(2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('20,000', 'he-il')).toBeCloseTo(20000, supportedNumberOfFractionDigits);
+    expect(getNumber('20000', 'he-il')).toBeCloseTo(20000, supportedNumberOfFractionDigits);
+    expect(getNumber('20,000.34', 'he-il')).toBeCloseTo(20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('20000.34', 'he-il')).toBeCloseTo(20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('200,000', 'he-il')).toBeCloseTo(200000, supportedNumberOfFractionDigits);
+    expect(getNumber('200000', 'he-il')).toBeCloseTo(200000, supportedNumberOfFractionDigits);
+    expect(getNumber('2,000,000', 'he-il')).toBeCloseTo(2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('2000000', 'he-il')).toBeCloseTo(2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('12,054,100.55', 'he-il')).toBeCloseTo(12054100.55, supportedNumberOfFractionDigits);
+    expect(getNumber('12054100.55', 'he-il')).toBeCloseTo(12054100.55, supportedNumberOfFractionDigits);
+  });
+
+  test(`(Manually) It should return a positive decimal literal when given an 
+  explicitly positive string representation`, () => {
+    expect(getNumber('+0.0', 'he-il')).toBeCloseTo(0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+0.45', 'he-il')).toBeCloseTo(0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('+0.3', 'he-il')).toBeCloseTo(0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('+0.243225', 'he-il')).toBeCloseTo(0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('+200', 'he-il')).toBeCloseTo(200, supportedNumberOfFractionDigits);
+    expect(getNumber('+200.45', 'he-il')).toBeCloseTo(200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('+873.00', 'he-il')).toBeCloseTo(873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+2,050', 'he-il')).toBeCloseTo(2050, supportedNumberOfFractionDigits);
+    expect(getNumber('+2050', 'he-il')).toBeCloseTo(2050, supportedNumberOfFractionDigits);
+    expect(getNumber('+2,000.30', 'he-il')).toBeCloseTo(2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('+2000.30', 'he-il')).toBeCloseTo(2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('+2,342.0', 'he-il')).toBeCloseTo(2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+2342.0', 'he-il')).toBeCloseTo(2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+20,000', 'he-il')).toBeCloseTo(20000, supportedNumberOfFractionDigits);
+    expect(getNumber('+20000', 'he-il')).toBeCloseTo(20000, supportedNumberOfFractionDigits);
+    expect(getNumber('+20,000.34', 'he-il')).toBeCloseTo(20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('+20000.34', 'he-il')).toBeCloseTo(20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('+200,000', 'he-il')).toBeCloseTo(200000, supportedNumberOfFractionDigits);
+    expect(getNumber('+200000', 'he-il')).toBeCloseTo(200000, supportedNumberOfFractionDigits);
+    expect(getNumber('+2,000,000', 'he-il')).toBeCloseTo(2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('+2000000', 'he-il')).toBeCloseTo(2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('+12,054,100.55', 'he-il')).toBeCloseTo(12054100.55, supportedNumberOfFractionDigits);
+    expect(getNumber('+12054100.55', 'he-il')).toBeCloseTo(12054100.55, supportedNumberOfFractionDigits);
+  });
+
+  test(`(Automatically)(Range: [0, 1]) It should return a possible decimal literal when given an
+  implicitly positive string representation`, () => {
+    const testCases = testCaseGenerator('he-il', 0, 0, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'he-il')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [1, 100]) It should return a possible decimal literal when given an
+  implicitly positive string representation`, () => {
+    const testCases = testCaseGenerator('he-il', 1, 100, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'he-il')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [100, 1.000]) It should return a possible decimal literal when given an
+  implicitly positive string representation`, () => {
+    const testCases = testCaseGenerator('he-il', 100, 1000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'he-il')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [1.000, 10.000]) It should return a possible decimal literal when given an
+  implicitly positive string representation`, () => {
+    const testCases = testCaseGenerator('he-il', 1000, 10000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'he-il')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [10.000, 100.000]) It should return a possible decimal literal when given an
+  implicitly positive string representation`, () => {
+    const testCases = testCaseGenerator('he-il', 10000, 100000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'he-il')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [100.000, 1.000.000]) It should return a possible decimal literal when given an
+  implicitly positive string representation`, () => {
+    const testCases = testCaseGenerator('he-il', 100000, 1000000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'he-il')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [1.000.000, 10.000.000]) It should return a possible decimal literal when given an
+  implicitly positive string representation`, () => {
+    const testCases = testCaseGenerator('he-il', 1000000, 10000000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'he-il')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [10.000.000, 100.000.000]) It should return a possible decimal literal when given an
+  implicitly positive string representation`, () => {
+    const testCases = testCaseGenerator('he-il', 10000000, 100000000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'he-il')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [100.000.000, 1.000.000.000]) It should return a possible decimal literal when given an
+  implicitly positive string representation`, () => {
+    const testCases = testCaseGenerator('he-il', 100000000, 1000000000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'he-il')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [1.000.000.000, 10.000.000.000]) It should return a possible decimal literal when given an
+  implicitly positive string representation`, () => {
+    const testCases = testCaseGenerator('he-il', 1000000000, 10000000000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'he-il')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [10.000.000.000, 100.000.000.000]) It should return a possible decimal literal when given an
+  implicitly positive string representation`, () => {
+    const testCases = testCaseGenerator('he-il', 10000000000, 100000000000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'he-il')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [100.000.000.000, 1.000.000.000.000]) It should return a possible decimal literal when given an
+  implicitly positive string representation`, () => {
+    const testCases = testCaseGenerator('he-il', 100000000000, 1000000000000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'he-il')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [1.000.000.000.000, 10.000.000.000.000]) It should return a possible decimal literal when given an
+  implicitly positive string representation`, () => {
+    const testCases = testCaseGenerator('he-il', 1000000000000, 10000000000000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'he-il')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [10.000.000.000.000, 100.000.000.000.000]) It should return a possible decimal literal when given an
+  implicitly positive string representation`, () => {
+    const testCases = testCaseGenerator('he-il', 10000000000000, 100000000000000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'he-il')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+});
+
+describe('Testing `getNumber` with `he-il` locale on negative numbers', () => {
+  test(`(Manually) It should return a negative decimal literal when given a
+  negative string representation`, () => {
+    expect(getNumber('-0.0', 'he-il')).toBeCloseTo(-0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-0.45', 'he-il')).toBeCloseTo(-0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('-0.3', 'he-il')).toBeCloseTo(-0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('-0.243225', 'he-il')).toBeCloseTo(-0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('-200', 'he-il')).toBeCloseTo(-200, supportedNumberOfFractionDigits);
+    expect(getNumber('-200.45', 'he-il')).toBeCloseTo(-200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('-873.00', 'he-il')).toBeCloseTo(-873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-2,050', 'he-il')).toBeCloseTo(-2050, supportedNumberOfFractionDigits);
+    expect(getNumber('-2050', 'he-il')).toBeCloseTo(-2050, supportedNumberOfFractionDigits);
+    expect(getNumber('-2,000.30', 'he-il')).toBeCloseTo(-2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('-2000.30', 'he-il')).toBeCloseTo(-2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('-2,342.0', 'he-il')).toBeCloseTo(-2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-2342.0', 'he-il')).toBeCloseTo(-2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-20,000', 'he-il')).toBeCloseTo(-20000, supportedNumberOfFractionDigits);
+    expect(getNumber('-20000', 'he-il')).toBeCloseTo(-20000, supportedNumberOfFractionDigits);
+    expect(getNumber('-20,000.34', 'he-il')).toBeCloseTo(-20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('-20000.34', 'he-il')).toBeCloseTo(-20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('-200,000', 'he-il')).toBeCloseTo(-200000, supportedNumberOfFractionDigits);
+    expect(getNumber('-200000', 'he-il')).toBeCloseTo(-200000, supportedNumberOfFractionDigits);
+    expect(getNumber('-2,000,000', 'he-il')).toBeCloseTo(-2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('-2000000', 'he-il')).toBeCloseTo(-2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('-12,054,100.55', 'he-il')).toBeCloseTo(-12054100.55, supportedNumberOfFractionDigits);
+    expect(getNumber('-12054100.55', 'he-il')).toBeCloseTo(-12054100.55, supportedNumberOfFractionDigits);
+  });
+
+  test(`(Automatically)(Range: [-1, 0]) It should return a possible decimal literal when given an
+  negative string representation`, () => {
+    const testCases = testCaseGenerator('he-il', 0, -2, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'he-il')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [-100, -1]) It should return a possible decimal literal when given an
+  negative string representation`, () => {
+    const testCases = testCaseGenerator('he-il', -100, -1, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'he-il')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [-1.000, -100]) It should return a possible decimal literal when given an
+  negative string representation`, () => {
+    const testCases = testCaseGenerator('he-il', -1000, -100, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'he-il')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [-10.000, -1.000]) It should return a possible decimal literal when given an
+  negative string representation`, () => {
+    const testCases = testCaseGenerator('he-il', -10000, -1000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'he-il')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [-100.000, -10.000]) It should return a possible decimal literal when given an
+  negative string representation`, () => {
+    const testCases = testCaseGenerator('he-il', -100000, -10000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'he-il')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [-1.000.000, -100.000]) It should return a possible decimal literal when given an
+  negative string representation`, () => {
+    const testCases = testCaseGenerator('he-il', -1000000, -100000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'he-il')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [-10.000.000, -1.000.000]) It should return a possible decimal literal when given an
+  negative string representation`, () => {
+    const testCases = testCaseGenerator('he-il', -10000000, -1000000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'he-il')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [-100.000.000, -10.000.000]) It should return a possible decimal literal when given an
+  negative string representation`, () => {
+    const testCases = testCaseGenerator('he-il', -100000000, -10000000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'he-il')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [-1.000.000.000, -100.000.000]) It should return a possible decimal literal when given an
+  negative string representation`, () => {
+    const testCases = testCaseGenerator('he-il', -1000000000, -100000000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'he-il')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [-10.000.000.000, -1.000.000.000]) It should return a possible decimal literal when given an
+  negative string representation`, () => {
+    const testCases = testCaseGenerator('he-il', -10000000000, -1000000000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'he-il')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [-100.000.000.000, -10.000.000.000]) It should return a possible decimal literal when given an
+  negative string representation`, () => {
+    const testCases = testCaseGenerator('he-il', -100000000000, -10000000000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'he-il')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [-1.000.000.000.000, -100.000.000.000]) It should return a possible decimal literal when given an
+  negative string representation`, () => {
+    const testCases = testCaseGenerator('he-il', -1000000000000, -100000000000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'he-il')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [-10.000.000.000.000, -1.000.000.000.000]) It should return a possible decimal literal when given an
+  negative string representation`, () => {
+    const testCases = testCaseGenerator('he-il', -10000000000000, -1000000000000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'he-il')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+});
+
+describe('Testing `getNumber` with `he-il` locale on invalid cases', () => {
+  test(`(Manually) It should return 'null' when locale is not supported`, () => {
+    expect(getNumber('120', 'unsupported-locale')).toBe(null);
+  });
+
+  test(`(Manually) It should return 'null' when the given number does not
+  match the given locale`, () => {
+    expect(getNumber('120.000,23', 'he-il')).toBe(null);
+    expect(getNumber('12 000.23', 'he-il')).toBe(null);
+    expect(getNumber("12'000,23", 'he-il')).toBe(null);
+  });
+});

--- a/src/get-number/specs/get-number.he.spec.js
+++ b/src/get-number/specs/get-number.he.spec.js
@@ -1,0 +1,403 @@
+const getNumber = require('../get-number');
+const { testCaseGenerator, supportedNumberOfFractionDigits } = require('./test-case-generator');
+
+beforeEach(() => {
+  // Making sure the `console.error` implementation is empty
+  // in order to avoid tests failing when a warning is logged.
+  jest.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+describe('Testing `getNumber` with `he` locale on positive numbers', () => {
+  test(`(Manually) It should return a positive decimal literal when given an 
+  implicitly positive string representation`, () => {
+    expect(getNumber('0.0', 'he')).toBeCloseTo(0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('0.45', 'he')).toBeCloseTo(0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('0.3', 'he')).toBeCloseTo(0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('0.243225', 'he')).toBeCloseTo(0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('200', 'he')).toBeCloseTo(200, supportedNumberOfFractionDigits);
+    expect(getNumber('200.45', 'he')).toBeCloseTo(200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('873.00', 'he')).toBeCloseTo(873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('2,050', 'he')).toBeCloseTo(2050, supportedNumberOfFractionDigits);
+    expect(getNumber('2050', 'he')).toBeCloseTo(2050, supportedNumberOfFractionDigits);
+    expect(getNumber('2,000.30', 'he')).toBeCloseTo(2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('2000.30', 'he')).toBeCloseTo(2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('2,342.0', 'he')).toBeCloseTo(2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('2342.0', 'he')).toBeCloseTo(2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('20,000', 'he')).toBeCloseTo(20000, supportedNumberOfFractionDigits);
+    expect(getNumber('20000', 'he')).toBeCloseTo(20000, supportedNumberOfFractionDigits);
+    expect(getNumber('20,000.34', 'he')).toBeCloseTo(20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('20000.34', 'he')).toBeCloseTo(20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('200,000', 'he')).toBeCloseTo(200000, supportedNumberOfFractionDigits);
+    expect(getNumber('200000', 'he')).toBeCloseTo(200000, supportedNumberOfFractionDigits);
+    expect(getNumber('2,000,000', 'he')).toBeCloseTo(2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('2000000', 'he')).toBeCloseTo(2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('12,054,100.55', 'he')).toBeCloseTo(12054100.55, supportedNumberOfFractionDigits);
+    expect(getNumber('12054100.55', 'he')).toBeCloseTo(12054100.55, supportedNumberOfFractionDigits);
+  });
+
+  test(`(Manually) It should return a positive decimal literal when given an 
+  explicitly positive string representation`, () => {
+    expect(getNumber('+0.0', 'he')).toBeCloseTo(0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+0.45', 'he')).toBeCloseTo(0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('+0.3', 'he')).toBeCloseTo(0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('+0.243225', 'he')).toBeCloseTo(0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('+200', 'he')).toBeCloseTo(200, supportedNumberOfFractionDigits);
+    expect(getNumber('+200.45', 'he')).toBeCloseTo(200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('+873.00', 'he')).toBeCloseTo(873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+2,050', 'he')).toBeCloseTo(2050, supportedNumberOfFractionDigits);
+    expect(getNumber('+2050', 'he')).toBeCloseTo(2050, supportedNumberOfFractionDigits);
+    expect(getNumber('+2,000.30', 'he')).toBeCloseTo(2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('+2000.30', 'he')).toBeCloseTo(2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('+2,342.0', 'he')).toBeCloseTo(2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+2342.0', 'he')).toBeCloseTo(2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('+20,000', 'he')).toBeCloseTo(20000, supportedNumberOfFractionDigits);
+    expect(getNumber('+20000', 'he')).toBeCloseTo(20000, supportedNumberOfFractionDigits);
+    expect(getNumber('+20,000.34', 'he')).toBeCloseTo(20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('+20000.34', 'he')).toBeCloseTo(20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('+200,000', 'he')).toBeCloseTo(200000, supportedNumberOfFractionDigits);
+    expect(getNumber('+200000', 'he')).toBeCloseTo(200000, supportedNumberOfFractionDigits);
+    expect(getNumber('+2,000,000', 'he')).toBeCloseTo(2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('+2000000', 'he')).toBeCloseTo(2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('+12,054,100.55', 'he')).toBeCloseTo(12054100.55, supportedNumberOfFractionDigits);
+    expect(getNumber('+12054100.55', 'he')).toBeCloseTo(12054100.55, supportedNumberOfFractionDigits);
+  });
+
+  test(`(Automatically)(Range: [0, 1]) It should return a possible decimal literal when given an
+  implicitly positive string representation`, () => {
+    const testCases = testCaseGenerator('he', 0, 0, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'he')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [1, 100]) It should return a possible decimal literal when given an
+  implicitly positive string representation`, () => {
+    const testCases = testCaseGenerator('he', 1, 100, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'he')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [100, 1.000]) It should return a possible decimal literal when given an
+  implicitly positive string representation`, () => {
+    const testCases = testCaseGenerator('he', 100, 1000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'he')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [1.000, 10.000]) It should return a possible decimal literal when given an
+  implicitly positive string representation`, () => {
+    const testCases = testCaseGenerator('he', 1000, 10000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'he')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [10.000, 100.000]) It should return a possible decimal literal when given an
+  implicitly positive string representation`, () => {
+    const testCases = testCaseGenerator('he', 10000, 100000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'he')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [100.000, 1.000.000]) It should return a possible decimal literal when given an
+  implicitly positive string representation`, () => {
+    const testCases = testCaseGenerator('he', 100000, 1000000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'he')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [1.000.000, 10.000.000]) It should return a possible decimal literal when given an
+  implicitly positive string representation`, () => {
+    const testCases = testCaseGenerator('he', 1000000, 10000000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'he')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [10.000.000, 100.000.000]) It should return a possible decimal literal when given an
+  implicitly positive string representation`, () => {
+    const testCases = testCaseGenerator('he', 10000000, 100000000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'he')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [100.000.000, 1.000.000.000]) It should return a possible decimal literal when given an
+  implicitly positive string representation`, () => {
+    const testCases = testCaseGenerator('he', 100000000, 1000000000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'he')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [1.000.000.000, 10.000.000.000]) It should return a possible decimal literal when given an
+  implicitly positive string representation`, () => {
+    const testCases = testCaseGenerator('he', 1000000000, 10000000000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'he')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [10.000.000.000, 100.000.000.000]) It should return a possible decimal literal when given an
+  implicitly positive string representation`, () => {
+    const testCases = testCaseGenerator('he', 10000000000, 100000000000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'he')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [100.000.000.000, 1.000.000.000.000]) It should return a possible decimal literal when given an
+  implicitly positive string representation`, () => {
+    const testCases = testCaseGenerator('he', 100000000000, 1000000000000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'he')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [1.000.000.000.000, 10.000.000.000.000]) It should return a possible decimal literal when given an
+  implicitly positive string representation`, () => {
+    const testCases = testCaseGenerator('he', 1000000000000, 10000000000000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'he')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [10.000.000.000.000, 100.000.000.000.000]) It should return a possible decimal literal when given an
+  implicitly positive string representation`, () => {
+    const testCases = testCaseGenerator('he', 10000000000000, 100000000000000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'he')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+});
+
+describe('Testing `getNumber` with `he` locale on negative numbers', () => {
+  test(`(Manually) It should return a negative decimal literal when given a
+  negative string representation`, () => {
+    expect(getNumber('-0.0', 'he')).toBeCloseTo(-0.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-0.45', 'he')).toBeCloseTo(-0.45, supportedNumberOfFractionDigits);
+    expect(getNumber('-0.3', 'he')).toBeCloseTo(-0.3, supportedNumberOfFractionDigits);
+    expect(getNumber('-0.243225', 'he')).toBeCloseTo(-0.243225, supportedNumberOfFractionDigits);
+    expect(getNumber('-200', 'he')).toBeCloseTo(-200, supportedNumberOfFractionDigits);
+    expect(getNumber('-200.45', 'he')).toBeCloseTo(-200.45, supportedNumberOfFractionDigits);
+    expect(getNumber('-873.00', 'he')).toBeCloseTo(-873.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-2,050', 'he')).toBeCloseTo(-2050, supportedNumberOfFractionDigits);
+    expect(getNumber('-2050', 'he')).toBeCloseTo(-2050, supportedNumberOfFractionDigits);
+    expect(getNumber('-2,000.30', 'he')).toBeCloseTo(-2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('-2000.30', 'he')).toBeCloseTo(-2000.3, supportedNumberOfFractionDigits);
+    expect(getNumber('-2,342.0', 'he')).toBeCloseTo(-2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-2342.0', 'he')).toBeCloseTo(-2342.0, supportedNumberOfFractionDigits);
+    expect(getNumber('-20,000', 'he')).toBeCloseTo(-20000, supportedNumberOfFractionDigits);
+    expect(getNumber('-20000', 'he')).toBeCloseTo(-20000, supportedNumberOfFractionDigits);
+    expect(getNumber('-20,000.34', 'he')).toBeCloseTo(-20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('-20000.34', 'he')).toBeCloseTo(-20000.34, supportedNumberOfFractionDigits);
+    expect(getNumber('-200,000', 'he')).toBeCloseTo(-200000, supportedNumberOfFractionDigits);
+    expect(getNumber('-200000', 'he')).toBeCloseTo(-200000, supportedNumberOfFractionDigits);
+    expect(getNumber('-2,000,000', 'he')).toBeCloseTo(-2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('-2000000', 'he')).toBeCloseTo(-2000000, supportedNumberOfFractionDigits);
+    expect(getNumber('-12,054,100.55', 'he')).toBeCloseTo(-12054100.55, supportedNumberOfFractionDigits);
+    expect(getNumber('-12054100.55', 'he')).toBeCloseTo(-12054100.55, supportedNumberOfFractionDigits);
+  });
+
+  test(`(Automatically)(Range: [-1, 0]) It should return a possible decimal literal when given an
+  negative string representation`, () => {
+    const testCases = testCaseGenerator('he', 0, -2, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'he')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [-100, -1]) It should return a possible decimal literal when given an
+  negative string representation`, () => {
+    const testCases = testCaseGenerator('he', -100, -1, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'he')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [-1.000, -100]) It should return a possible decimal literal when given an
+  negative string representation`, () => {
+    const testCases = testCaseGenerator('he', -1000, -100, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'he')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [-10.000, -1.000]) It should return a possible decimal literal when given an
+  negative string representation`, () => {
+    const testCases = testCaseGenerator('he', -10000, -1000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'he')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [-100.000, -10.000]) It should return a possible decimal literal when given an
+  negative string representation`, () => {
+    const testCases = testCaseGenerator('he', -100000, -10000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'he')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [-1.000.000, -100.000]) It should return a possible decimal literal when given an
+  negative string representation`, () => {
+    const testCases = testCaseGenerator('he', -1000000, -100000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'he')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [-10.000.000, -1.000.000]) It should return a possible decimal literal when given an
+  negative string representation`, () => {
+    const testCases = testCaseGenerator('he', -10000000, -1000000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'he')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [-100.000.000, -10.000.000]) It should return a possible decimal literal when given an
+  negative string representation`, () => {
+    const testCases = testCaseGenerator('he', -100000000, -10000000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'he')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [-1.000.000.000, -100.000.000]) It should return a possible decimal literal when given an
+  negative string representation`, () => {
+    const testCases = testCaseGenerator('he', -1000000000, -100000000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'he')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [-10.000.000.000, -1.000.000.000]) It should return a possible decimal literal when given an
+  negative string representation`, () => {
+    const testCases = testCaseGenerator('he', -10000000000, -1000000000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'he')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [-100.000.000.000, -10.000.000.000]) It should return a possible decimal literal when given an
+  negative string representation`, () => {
+    const testCases = testCaseGenerator('he', -100000000000, -10000000000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'he')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [-1.000.000.000.000, -100.000.000.000]) It should return a possible decimal literal when given an
+  negative string representation`, () => {
+    const testCases = testCaseGenerator('he', -1000000000000, -100000000000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'he')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+
+  test(`(Automatically)(Range: [-10.000.000.000.000, -1.000.000.000.000]) It should return a possible decimal literal when given an
+  negative string representation`, () => {
+    const testCases = testCaseGenerator('he', -10000000000000, -1000000000000, 1000);
+    testCases.forEach((testCase) => {
+      expect(getNumber(testCase.stringRepresentation, 'he')).toBeCloseTo(
+        testCase.groundTruth,
+        supportedNumberOfFractionDigits
+      );
+    });
+  });
+});
+
+describe('Testing `getNumber` with `he` locale on invalid cases', () => {
+  test(`(Manually) It should return 'null' when locale is not supported`, () => {
+    expect(getNumber('120', 'unsupported-locale')).toBe(null);
+  });
+
+  test(`(Manually) It should return 'null' when the given number does not
+  match the given locale`, () => {
+    expect(getNumber('120.000,23', 'he')).toBe(null);
+    expect(getNumber('12 000.23', 'he')).toBe(null);
+    expect(getNumber("12'000,23", 'he')).toBe(null);
+  });
+});

--- a/src/get-number/specs/test-case-generator.js
+++ b/src/get-number/specs/test-case-generator.js
@@ -38,7 +38,7 @@ function testCaseGenerator(locale, from, to, numberOfTestCases) {
         stringRepresentation: new Intl.NumberFormat(locale.toLowerCase(), {
           minimumFractionDigits: supportedNumberOfFractionDigits + 1,
           maximumFractionDigits: supportedNumberOfFractionDigits + 1,
-        }).format(groundTruth),
+        }).format(groundTruth).replace(/[^.,\d +\u2212\u002d\ufe63\uff0d]/g, ''),
       });
     } else {
       const groundTruth = randomFloat(from, to);
@@ -47,7 +47,7 @@ function testCaseGenerator(locale, from, to, numberOfTestCases) {
         stringRepresentation: new Intl.NumberFormat(locale.toLowerCase(), {
           minimumFractionDigits: supportedNumberOfFractionDigits + 1,
           maximumFractionDigits: supportedNumberOfFractionDigits + 1,
-        }).format(groundTruth),
+        }).format(groundTruth).replace(/[^.,\d +\u2212\u002d\ufe63\uff0d]/g, ''),
       });
     }
     integer = !integer;

--- a/src/locale-mapper.js
+++ b/src/locale-mapper.js
@@ -138,6 +138,14 @@ const localeMapper = {
     thousands: '[\\u202F\\u00A0\\u2000\\u2001\\u2003\\s]?',
     decimal: '\\,',
   },
+  'he': {
+    thousands: '\\,?',
+    decimal: '\\.',
+  },
+  'he-il': {
+    thousands: '\\,?',
+    decimal: '\\.',
+  },
   'hi': {
     thousands: '\\,?',
     decimal: '\\.',


### PR DESCRIPTION
# Description

This MR contains the wiring of the Hebrew locales (`he` and `he-IL`). Additionally, it contains the unit tests required to make sure the new functionality works as expected.

Fixes #15 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

It was tested by following the instructions in the Wiki page. Basically, we have created 2 new specs for the two locale configurations.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
